### PR TITLE
[Feat] entity creation

### DIFF
--- a/api-server/src/main/java/com/whyitrose/apiserver/WhyItRoseApplication.java
+++ b/api-server/src/main/java/com/whyitrose/apiserver/WhyItRoseApplication.java
@@ -4,8 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 @EntityScan(basePackages = "com.whyitrose")
 @EnableJpaRepositories(basePackages = "com.whyitrose")
 public class WhyItRoseApplication {

--- a/domain/src/main/java/com/whyitrose/domain/common/BaseTimeEntity.java
+++ b/domain/src/main/java/com/whyitrose/domain/common/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package com.whyitrose.domain.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false, insertable = false)
+    private LocalDateTime updatedAt;
+}

--- a/domain/src/main/java/com/whyitrose/domain/common/Status.java
+++ b/domain/src/main/java/com/whyitrose/domain/common/Status.java
@@ -1,0 +1,16 @@
+package com.whyitrose.domain.common;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Status {
+
+    PENDING("대기"),
+    ACTIVE("활성"),
+    INACTIVE("비활성"),
+    DELETED("삭제");
+
+    private final String description;
+}

--- a/domain/src/main/java/com/whyitrose/domain/digest/DailyNewsDigest.java
+++ b/domain/src/main/java/com/whyitrose/domain/digest/DailyNewsDigest.java
@@ -1,0 +1,65 @@
+package com.whyitrose.domain.digest;
+
+import com.whyitrose.domain.common.BaseTimeEntity;
+import com.whyitrose.domain.common.Status;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(
+        name = "daily_news_digest",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_daily_news_digest_date", columnNames = {"digest_date"})
+        },
+        indexes = {
+                @Index(name = "idx_daily_news_digest_status", columnList = "status")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DailyNewsDigest extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    // 큐레이션 기준일
+    @Column(name = "digest_date", nullable = false)
+    private LocalDate digestDate;
+
+    // DEFAULT 0
+    @Column(name = "total_news_count", nullable = false)
+    private int totalNewsCount;
+
+    // DEFAULT 'PENDING'
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private Status status;
+
+    @OneToMany(mappedBy = "digest", fetch = FetchType.LAZY)
+    private List<DailyNewsDigestItem> items = new ArrayList<>();
+
+    public static DailyNewsDigest create(LocalDate digestDate) {
+        DailyNewsDigest digest = new DailyNewsDigest();
+        digest.digestDate = digestDate;
+        digest.totalNewsCount = 0;
+        digest.status = Status.PENDING;
+        return digest;
+    }
+
+    public void activate(int totalNewsCount) {
+        this.totalNewsCount = totalNewsCount;
+        this.status = Status.ACTIVE;
+    }
+
+    public void delete() {
+        this.status = Status.DELETED;
+    }
+}

--- a/domain/src/main/java/com/whyitrose/domain/digest/DailyNewsDigestItem.java
+++ b/domain/src/main/java/com/whyitrose/domain/digest/DailyNewsDigestItem.java
@@ -1,0 +1,67 @@
+package com.whyitrose.domain.digest;
+
+import com.whyitrose.domain.common.BaseTimeEntity;
+import com.whyitrose.domain.common.Status;
+import com.whyitrose.domain.news.News;
+import com.whyitrose.domain.stock.Stock;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "daily_news_digest_items",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_digest_items", columnNames = {"digest_id", "news_id", "stock_id"})
+        },
+        indexes = {
+                @Index(name = "idx_digest_items_stock", columnList = "digest_id, stock_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DailyNewsDigestItem extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "digest_id", nullable = false)
+    private DailyNewsDigest digest;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "news_id", nullable = false)
+    private News news;
+
+    // 해당 뉴스의 대표 종목 — 알림센터 종목 필터링 최적화용 비정규화 컬럼
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "stock_id", nullable = false)
+    private Stock stock;
+
+    // DEFAULT 'ACTIVE'
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private Status status;
+
+    public static DailyNewsDigestItem create(DailyNewsDigest digest, News news, Stock stock) {
+        DailyNewsDigestItem item = new DailyNewsDigestItem();
+        item.digest = digest;
+        item.news = news;
+        item.stock = stock;
+        item.status = Status.ACTIVE;
+        return item;
+    }
+
+    // 연관관계 편의 메서드
+    public void assignDigest(DailyNewsDigest digest) {
+        this.digest = digest;
+        digest.getItems().add(this);
+    }
+
+    public void delete() {
+        this.status = Status.DELETED;
+    }
+}

--- a/domain/src/main/java/com/whyitrose/domain/digest/DailyNewsDigestItemRepository.java
+++ b/domain/src/main/java/com/whyitrose/domain/digest/DailyNewsDigestItemRepository.java
@@ -1,0 +1,14 @@
+package com.whyitrose.domain.digest;
+
+import com.whyitrose.domain.common.Status;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface DailyNewsDigestItemRepository extends JpaRepository<DailyNewsDigestItem, Long> {
+
+    // idx_digest_items_stock 활용 — 알림센터 종목 필터링
+    List<DailyNewsDigestItem> findByDigestIdAndStockIdAndStatus(Long digestId, Long stockId, Status status);
+
+    List<DailyNewsDigestItem> findByDigestIdAndStatus(Long digestId, Status status);
+}

--- a/domain/src/main/java/com/whyitrose/domain/digest/DailyNewsDigestRepository.java
+++ b/domain/src/main/java/com/whyitrose/domain/digest/DailyNewsDigestRepository.java
@@ -1,0 +1,14 @@
+package com.whyitrose.domain.digest;
+
+import com.whyitrose.domain.common.Status;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface DailyNewsDigestRepository extends JpaRepository<DailyNewsDigest, Long> {
+
+    Optional<DailyNewsDigest> findByDigestDate(LocalDate digestDate);
+
+    Optional<DailyNewsDigest> findByDigestDateAndStatus(LocalDate digestDate, Status status);
+}

--- a/domain/src/main/java/com/whyitrose/domain/event/Event.java
+++ b/domain/src/main/java/com/whyitrose/domain/event/Event.java
@@ -1,0 +1,103 @@
+package com.whyitrose.domain.event;
+
+import com.whyitrose.domain.common.BaseTimeEntity;
+import com.whyitrose.domain.common.Status;
+import com.whyitrose.domain.stock.Stock;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(
+        name = "events",
+        indexes = {
+                @Index(name = "idx_events_stock_date", columnList = "stock_id, start_date"),
+                @Index(name = "idx_events_status", columnList = "status")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Event extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "stock_id", nullable = false)
+    private Stock stock;
+
+    // SURGE | DROP
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_type", length = 10, nullable = false)
+    private EventType eventType;
+
+    // 이벤트 시작일
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    // 이벤트 종료일 — 단일이면 start_date와 동일
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    // 기간 누적 등락률
+    @Column(name = "change_pct", nullable = false, precision = 6, scale = 2)
+    private BigDecimal changePct;
+
+    // 시작일 전일 종가 스냅샷
+    @Column(name = "price_before", nullable = false)
+    private int priceBefore;
+
+    // 종료일 종가 스냅샷
+    @Column(name = "price_after", nullable = false)
+    private int priceAfter;
+
+    // AI 요약 1~3문장
+    @Column(name = "summary", columnDefinition = "TEXT")
+    private String summary;
+
+    // DEFAULT 'PENDING'
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private Status status;
+
+    @OneToMany(mappedBy = "event", fetch = FetchType.LAZY)
+    private List<EventNews> eventNewsList = new ArrayList<>();
+
+    public static Event create(Stock stock, EventType eventType,
+                               LocalDate startDate, LocalDate endDate,
+                               BigDecimal changePct, int priceBefore, int priceAfter) {
+        Event event = new Event();
+        event.stock = stock;
+        event.eventType = eventType;
+        event.startDate = startDate;
+        event.endDate = endDate;
+        event.changePct = changePct;
+        event.priceBefore = priceBefore;
+        event.priceAfter = priceAfter;
+        event.status = Status.PENDING;
+        return event;
+    }
+
+    // 연관관계 편의 메서드
+    public void assignStock(Stock stock) {
+        this.stock = stock;
+        stock.getEvents().add(this);
+    }
+
+    public void activate(String summary) {
+        this.summary = summary;
+        this.status = Status.ACTIVE;
+    }
+
+    public void delete() {
+        this.status = Status.DELETED;
+    }
+}

--- a/domain/src/main/java/com/whyitrose/domain/event/EventNews.java
+++ b/domain/src/main/java/com/whyitrose/domain/event/EventNews.java
@@ -1,0 +1,68 @@
+package com.whyitrose.domain.event;
+
+import com.whyitrose.domain.common.BaseTimeEntity;
+import com.whyitrose.domain.common.Status;
+import com.whyitrose.domain.news.News;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(
+        name = "event_news",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_event_news", columnNames = {"event_id", "news_id"})
+        },
+        indexes = {
+                // DDL: relevance_score DESC — Hibernate 6.x 지원
+                @Index(name = "idx_event_news_score", columnList = "event_id, relevance_score DESC")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EventNews extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "event_id", nullable = false)
+    private Event event;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "news_id", nullable = false)
+    private News news;
+
+    // 관련성 점수 0~1
+    @Column(name = "relevance_score", nullable = false, precision = 5, scale = 4)
+    private BigDecimal relevanceScore;
+
+    // DEFAULT 'ACTIVE'
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private Status status;
+
+    public static EventNews create(Event event, News news, BigDecimal relevanceScore) {
+        EventNews eventNews = new EventNews();
+        eventNews.event = event;
+        eventNews.news = news;
+        eventNews.relevanceScore = relevanceScore;
+        eventNews.status = Status.ACTIVE;
+        return eventNews;
+    }
+
+    // 연관관계 편의 메서드
+    public void assignEvent(Event event) {
+        this.event = event;
+        event.getEventNewsList().add(this);
+    }
+
+    public void delete() {
+        this.status = Status.DELETED;
+    }
+}

--- a/domain/src/main/java/com/whyitrose/domain/event/EventNewsRepository.java
+++ b/domain/src/main/java/com/whyitrose/domain/event/EventNewsRepository.java
@@ -1,0 +1,15 @@
+package com.whyitrose.domain.event;
+
+import com.whyitrose.domain.common.Status;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface EventNewsRepository extends JpaRepository<EventNews, Long> {
+
+    Optional<EventNews> findByEventIdAndNewsId(Long eventId, Long newsId);
+
+    // 관련성 점수 내림차순 — idx_event_news_score 활용
+    List<EventNews> findByEventIdAndStatusOrderByRelevanceScoreDesc(Long eventId, Status status);
+}

--- a/domain/src/main/java/com/whyitrose/domain/event/EventRepository.java
+++ b/domain/src/main/java/com/whyitrose/domain/event/EventRepository.java
@@ -1,0 +1,14 @@
+package com.whyitrose.domain.event;
+
+import com.whyitrose.domain.common.Status;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface EventRepository extends JpaRepository<Event, Long> {
+
+    List<Event> findByStockIdAndStatus(Long stockId, Status status, Pageable pageable);
+
+    List<Event> findByStatus(Status status);
+}

--- a/domain/src/main/java/com/whyitrose/domain/event/EventType.java
+++ b/domain/src/main/java/com/whyitrose/domain/event/EventType.java
@@ -1,0 +1,14 @@
+package com.whyitrose.domain.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum EventType {
+
+    SURGE("급등"),
+    DROP("급락");
+
+    private final String description;
+}

--- a/domain/src/main/java/com/whyitrose/domain/interest/InterestStock.java
+++ b/domain/src/main/java/com/whyitrose/domain/interest/InterestStock.java
@@ -1,0 +1,59 @@
+package com.whyitrose.domain.interest;
+
+import com.whyitrose.domain.common.BaseTimeEntity;
+import com.whyitrose.domain.common.Status;
+import com.whyitrose.domain.stock.Stock;
+import com.whyitrose.domain.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "interest_stocks",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_interest_stocks", columnNames = {"user_id", "stock_id"})
+        },
+        indexes = {
+                @Index(name = "idx_interest_stocks_stock", columnList = "stock_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InterestStock extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "stock_id", nullable = false)
+    private Stock stock;
+
+    // DEFAULT 'ACTIVE' / DELETED = 해제된 관심종목 (이력 보관)
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private Status status;
+
+    public static InterestStock create(User user, Stock stock) {
+        InterestStock interestStock = new InterestStock();
+        interestStock.user = user;
+        interestStock.stock = stock;
+        interestStock.status = Status.ACTIVE;
+        return interestStock;
+    }
+
+    public void delete() {
+        this.status = Status.DELETED;
+    }
+
+    public void reactivate() {
+        this.status = Status.ACTIVE;
+    }
+}

--- a/domain/src/main/java/com/whyitrose/domain/interest/InterestStockRepository.java
+++ b/domain/src/main/java/com/whyitrose/domain/interest/InterestStockRepository.java
@@ -1,0 +1,18 @@
+package com.whyitrose.domain.interest;
+
+import com.whyitrose.domain.common.Status;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface InterestStockRepository extends JpaRepository<InterestStock, Long> {
+
+    Optional<InterestStock> findByUserIdAndStockId(Long userId, Long stockId);
+
+    // 현재 활성 관심종목 목록
+    List<InterestStock> findByUserIdAndStatus(Long userId, Status status);
+
+    // idx_interest_stocks_stock 활용 — 종목별 관심 유저 수
+    long countByStockIdAndStatus(Long stockId, Status status);
+}

--- a/domain/src/main/java/com/whyitrose/domain/memo/Memo.java
+++ b/domain/src/main/java/com/whyitrose/domain/memo/Memo.java
@@ -1,0 +1,60 @@
+package com.whyitrose.domain.memo;
+
+import com.whyitrose.domain.common.BaseTimeEntity;
+import com.whyitrose.domain.common.Status;
+import com.whyitrose.domain.event.Event;
+import com.whyitrose.domain.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "memos",
+        indexes = {
+                @Index(name = "idx_memos_user_event", columnList = "user_id, event_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Memo extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "event_id", nullable = false)
+    private Event event;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    // DEFAULT 'ACTIVE'
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private Status status;
+
+    public static Memo create(User user, Event event, String content) {
+        Memo memo = new Memo();
+        memo.user = user;
+        memo.event = event;
+        memo.content = content;
+        memo.status = Status.ACTIVE;
+        return memo;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    public void delete() {
+        this.status = Status.DELETED;
+    }
+}

--- a/domain/src/main/java/com/whyitrose/domain/memo/MemoRepository.java
+++ b/domain/src/main/java/com/whyitrose/domain/memo/MemoRepository.java
@@ -1,0 +1,11 @@
+package com.whyitrose.domain.memo;
+
+import com.whyitrose.domain.common.Status;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MemoRepository extends JpaRepository<Memo, Long> {
+
+    List<Memo> findByUserIdAndEventIdAndStatus(Long userId, Long eventId, Status status);
+}

--- a/domain/src/main/java/com/whyitrose/domain/news/News.java
+++ b/domain/src/main/java/com/whyitrose/domain/news/News.java
@@ -1,0 +1,79 @@
+package com.whyitrose.domain.news;
+
+import com.whyitrose.domain.common.BaseTimeEntity;
+import com.whyitrose.domain.common.Status;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(
+        name = "news",
+        uniqueConstraints = {
+                // DDL: UNIQUE KEY uq_news_url (url(255)) — prefix 인덱스는 Flyway로 관리
+                @UniqueConstraint(name = "uq_news_url", columnNames = {"url"})
+        },
+        indexes = {
+                @Index(name = "idx_news_published_at", columnList = "published_at"),
+                @Index(name = "idx_news_status", columnList = "status")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class News extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "source", length = 100, nullable = false)
+    private String source;
+
+    @Column(name = "title", length = 500, nullable = false)
+    private String title;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    // 원문 링크 — DDL: VARCHAR(1000)
+    @Column(name = "url", length = 1000, nullable = false)
+    private String url;
+
+    @Column(name = "thumbnail_url", length = 500)
+    private String thumbnailUrl;
+
+    // 기사 발행시각
+    @Column(name = "published_at", nullable = false)
+    private LocalDateTime publishedAt;
+
+    // DEFAULT 'ACTIVE'
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private Status status;
+
+    @OneToMany(mappedBy = "news", fetch = FetchType.LAZY)
+    private List<NewsStock> newsStocks = new ArrayList<>();
+
+    public static News create(String source, String title, String content, String url,
+                              String thumbnailUrl, LocalDateTime publishedAt) {
+        News news = new News();
+        news.source = source;
+        news.title = title;
+        news.content = content;
+        news.url = url;
+        news.thumbnailUrl = thumbnailUrl;
+        news.publishedAt = publishedAt;
+        news.status = Status.ACTIVE;
+        return news;
+    }
+
+    public void delete() {
+        this.status = Status.DELETED;
+    }
+}

--- a/domain/src/main/java/com/whyitrose/domain/news/NewsRepository.java
+++ b/domain/src/main/java/com/whyitrose/domain/news/NewsRepository.java
@@ -1,0 +1,12 @@
+package com.whyitrose.domain.news;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface NewsRepository extends JpaRepository<News, Long> {
+
+    Optional<News> findByUrl(String url);
+
+    boolean existsByUrl(String url);
+}

--- a/domain/src/main/java/com/whyitrose/domain/news/NewsStock.java
+++ b/domain/src/main/java/com/whyitrose/domain/news/NewsStock.java
@@ -1,0 +1,60 @@
+package com.whyitrose.domain.news;
+
+import com.whyitrose.domain.common.BaseTimeEntity;
+import com.whyitrose.domain.common.Status;
+import com.whyitrose.domain.stock.Stock;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "news_stocks",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_news_stocks", columnNames = {"news_id", "stock_id"})
+        },
+        indexes = {
+                @Index(name = "idx_news_stocks_stock", columnList = "stock_id, news_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NewsStock extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "news_id", nullable = false)
+    private News news;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "stock_id", nullable = false)
+    private Stock stock;
+
+    // DEFAULT 'ACTIVE'
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private Status status;
+
+    public static NewsStock create(News news, Stock stock) {
+        NewsStock newsStock = new NewsStock();
+        newsStock.news = news;
+        newsStock.stock = stock;
+        newsStock.status = Status.ACTIVE;
+        return newsStock;
+    }
+
+    // 연관관계 편의 메서드
+    public void assignNews(News news) {
+        this.news = news;
+        news.getNewsStocks().add(this);
+    }
+
+    public void delete() {
+        this.status = Status.DELETED;
+    }
+}

--- a/domain/src/main/java/com/whyitrose/domain/news/NewsStockRepository.java
+++ b/domain/src/main/java/com/whyitrose/domain/news/NewsStockRepository.java
@@ -1,0 +1,14 @@
+package com.whyitrose.domain.news;
+
+import com.whyitrose.domain.common.Status;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface NewsStockRepository extends JpaRepository<NewsStock, Long> {
+
+    Optional<NewsStock> findByNewsIdAndStockId(Long newsId, Long stockId);
+
+    List<NewsStock> findByStockIdAndStatus(Long stockId, Status status);
+}

--- a/domain/src/main/java/com/whyitrose/domain/news/NewsTag.java
+++ b/domain/src/main/java/com/whyitrose/domain/news/NewsTag.java
@@ -1,0 +1,53 @@
+package com.whyitrose.domain.news;
+
+import com.whyitrose.domain.common.BaseTimeEntity;
+import com.whyitrose.domain.common.Status;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "news_tags",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_news_tags", columnNames = {"news_id", "tag_id"})
+        },
+        indexes = {
+                @Index(name = "idx_news_tags_tag", columnList = "tag_id, news_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NewsTag extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "news_id", nullable = false)
+    private News news;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "tag_id", nullable = false)
+    private Tag tag;
+
+    // DEFAULT 'ACTIVE'
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private Status status;
+
+    public static NewsTag create(News news, Tag tag) {
+        NewsTag newsTag = new NewsTag();
+        newsTag.news = news;
+        newsTag.tag = tag;
+        newsTag.status = Status.ACTIVE;
+        return newsTag;
+    }
+
+    public void delete() {
+        this.status = Status.DELETED;
+    }
+}

--- a/domain/src/main/java/com/whyitrose/domain/news/NewsTagRepository.java
+++ b/domain/src/main/java/com/whyitrose/domain/news/NewsTagRepository.java
@@ -1,0 +1,12 @@
+package com.whyitrose.domain.news;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NewsTagRepository extends JpaRepository<NewsTag, Long> {
+
+    List<NewsTag> findByNewsId(Long newsId);
+
+    List<NewsTag> findByTagId(Long tagId);
+}

--- a/domain/src/main/java/com/whyitrose/domain/news/Tag.java
+++ b/domain/src/main/java/com/whyitrose/domain/news/Tag.java
@@ -1,0 +1,45 @@
+package com.whyitrose.domain.news;
+
+import com.whyitrose.domain.common.BaseTimeEntity;
+import com.whyitrose.domain.common.Status;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "tags",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_tags_name", columnNames = {"name"})
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Tag extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    // ex) 실적, 정책, 수주
+    @Column(name = "name", length = 50, nullable = false)
+    private String name;
+
+    // DEFAULT 'ACTIVE'
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private Status status;
+
+    public static Tag create(String name) {
+        Tag tag = new Tag();
+        tag.name = name;
+        tag.status = Status.ACTIVE;
+        return tag;
+    }
+
+    public void delete() {
+        this.status = Status.DELETED;
+    }
+}

--- a/domain/src/main/java/com/whyitrose/domain/news/TagRepository.java
+++ b/domain/src/main/java/com/whyitrose/domain/news/TagRepository.java
@@ -1,0 +1,12 @@
+package com.whyitrose.domain.news;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+
+    Optional<Tag> findByName(String name);
+
+    boolean existsByName(String name);
+}

--- a/domain/src/main/java/com/whyitrose/domain/notification/Notification.java
+++ b/domain/src/main/java/com/whyitrose/domain/notification/Notification.java
@@ -1,0 +1,83 @@
+package com.whyitrose.domain.notification;
+
+import com.whyitrose.domain.common.BaseTimeEntity;
+import com.whyitrose.domain.common.Status;
+import com.whyitrose.domain.digest.DailyNewsDigest;
+import com.whyitrose.domain.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(
+        name = "notifications",
+        indexes = {
+                @Index(name = "idx_notifications_user_read", columnList = "user_id, read_at"),
+                @Index(name = "idx_notifications_user_date", columnList = "user_id, created_at DESC")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // NEWS 타입일 때만 값 존재, 나머지 타입은 null
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "digest_id")
+    private DailyNewsDigest digest;
+
+    // NEWS | EVENT | REVIEW | SYSTEM
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", length = 20, nullable = false)
+    private NotificationType type;
+
+    // null이면 안읽음
+    @Column(name = "read_at")
+    private LocalDateTime readAt;
+
+    // DEFAULT 'ACTIVE'
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private Status status;
+
+    @OneToMany(mappedBy = "notification", fetch = FetchType.LAZY)
+    private List<NotificationLog> logs = new ArrayList<>();
+
+    public static Notification create(User user, NotificationType type, DailyNewsDigest digest) {
+        Notification notification = new Notification();
+        notification.user = user;
+        notification.type = type;
+        notification.digest = digest;
+        notification.status = Status.ACTIVE;
+        return notification;
+    }
+
+    public static Notification create(User user, NotificationType type) {
+        return create(user, type, null);
+    }
+
+    public void markAsRead() {
+        this.readAt = LocalDateTime.now();
+    }
+
+    public boolean isRead() {
+        return this.readAt != null;
+    }
+
+    public void delete() {
+        this.status = Status.DELETED;
+    }
+}

--- a/domain/src/main/java/com/whyitrose/domain/notification/NotificationLog.java
+++ b/domain/src/main/java/com/whyitrose/domain/notification/NotificationLog.java
@@ -1,0 +1,72 @@
+package com.whyitrose.domain.notification;
+
+import com.whyitrose.domain.common.BaseTimeEntity;
+import com.whyitrose.domain.common.Status;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "notification_logs",
+        indexes = {
+                @Index(name = "idx_notification_logs_status", columnList = "notification_id, status")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationLog extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "notification_id", nullable = false)
+    private Notification notification;
+
+    // 발송용 문구 스냅샷 — {"title": "...", "body": "...", "link": "..."}
+    // JSON 타입: Jackson 으로 직렬화/역직렬화
+    @Column(name = "payload", nullable = false, columnDefinition = "JSON")
+    private String payload;
+
+    // DEFAULT 'PENDING'
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private Status status;
+
+    // 실제 발송 시각
+    @Column(name = "sent_at")
+    private LocalDateTime sentAt;
+
+    public static NotificationLog create(Notification notification, String payload) {
+        NotificationLog log = new NotificationLog();
+        log.notification = notification;
+        log.payload = payload;
+        log.status = Status.PENDING;
+        return log;
+    }
+
+    // 연관관계 편의 메서드
+    public void assignNotification(Notification notification) {
+        this.notification = notification;
+        notification.getLogs().add(this);
+    }
+
+    public void markAsSent() {
+        this.status = Status.ACTIVE;
+        this.sentAt = LocalDateTime.now();
+    }
+
+    public void markAsFailed() {
+        this.status = Status.INACTIVE;
+    }
+
+    public void delete() {
+        this.status = Status.DELETED;
+    }
+}

--- a/domain/src/main/java/com/whyitrose/domain/notification/NotificationLogRepository.java
+++ b/domain/src/main/java/com/whyitrose/domain/notification/NotificationLogRepository.java
@@ -1,0 +1,15 @@
+package com.whyitrose.domain.notification;
+
+import com.whyitrose.domain.common.Status;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface NotificationLogRepository extends JpaRepository<NotificationLog, Long> {
+
+    // idx_notification_logs_status 활용 — 재시도 대상 조회
+    List<NotificationLog> findByNotificationIdAndStatus(Long notificationId, Status status);
+
+    Optional<NotificationLog> findTopByNotificationIdOrderByCreatedAtDesc(Long notificationId);
+}

--- a/domain/src/main/java/com/whyitrose/domain/notification/NotificationRepository.java
+++ b/domain/src/main/java/com/whyitrose/domain/notification/NotificationRepository.java
@@ -1,0 +1,16 @@
+package com.whyitrose.domain.notification;
+
+import com.whyitrose.domain.common.Status;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    // idx_notifications_user_date 활용
+    List<Notification> findByUserIdAndStatusOrderByCreatedAtDesc(Long userId, Status status, Pageable pageable);
+
+    // 안읽은 알림 수
+    long countByUserIdAndReadAtIsNullAndStatus(Long userId, Status status);
+}

--- a/domain/src/main/java/com/whyitrose/domain/notification/NotificationType.java
+++ b/domain/src/main/java/com/whyitrose/domain/notification/NotificationType.java
@@ -1,0 +1,16 @@
+package com.whyitrose.domain.notification;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationType {
+
+    NEWS("뉴스"),
+    EVENT("이벤트"),
+    REVIEW("복기"),
+    SYSTEM("시스템");
+
+    private final String description;
+}

--- a/domain/src/main/java/com/whyitrose/domain/prediction/Prediction.java
+++ b/domain/src/main/java/com/whyitrose/domain/prediction/Prediction.java
@@ -1,0 +1,90 @@
+package com.whyitrose.domain.prediction;
+
+import com.whyitrose.domain.common.BaseTimeEntity;
+import com.whyitrose.domain.common.Status;
+import com.whyitrose.domain.notification.Notification;
+import com.whyitrose.domain.stock.Stock;
+import com.whyitrose.domain.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "predictions",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_predictions", columnNames = {"user_id", "notification_id", "stock_id"})
+        },
+        indexes = {
+                @Index(name = "idx_predictions_user", columnList = "user_id, created_at DESC")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Prediction extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "notification_id", nullable = false)
+    private Notification notification;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "stock_id", nullable = false)
+    private Stock stock;
+
+    // UP | DOWN | SIDEWAYS
+    @Enumerated(EnumType.STRING)
+    @Column(name = "direction", length = 10, nullable = false)
+    private PredictionDirection direction;
+
+    // 예측 근거
+    @Column(name = "reason", columnDefinition = "TEXT")
+    private String reason;
+
+    // 복기용 실제 등락률 — 배치로 채움
+    @Column(name = "actual_change_pct", precision = 6, scale = 2)
+    private BigDecimal actualChangePct;
+
+    // 복기 확인 시각
+    @Column(name = "reviewed_at")
+    private LocalDateTime reviewedAt;
+
+    // DEFAULT 'ACTIVE'
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private Status status;
+
+    public static Prediction create(User user, Notification notification, Stock stock,
+                                    PredictionDirection direction, String reason) {
+        Prediction prediction = new Prediction();
+        prediction.user = user;
+        prediction.notification = notification;
+        prediction.stock = stock;
+        prediction.direction = direction;
+        prediction.reason = reason;
+        prediction.status = Status.ACTIVE;
+        return prediction;
+    }
+
+    // 배치에서 실제 등락률을 채울 때 호출
+    public void review(BigDecimal actualChangePct) {
+        this.actualChangePct = actualChangePct;
+        this.reviewedAt = LocalDateTime.now();
+    }
+
+    public void delete() {
+        this.status = Status.DELETED;
+    }
+}

--- a/domain/src/main/java/com/whyitrose/domain/prediction/PredictionDirection.java
+++ b/domain/src/main/java/com/whyitrose/domain/prediction/PredictionDirection.java
@@ -1,0 +1,15 @@
+package com.whyitrose.domain.prediction;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PredictionDirection {
+
+    UP("상승"),
+    DOWN("하락"),
+    SIDEWAYS("횡보");
+
+    private final String description;
+}

--- a/domain/src/main/java/com/whyitrose/domain/prediction/PredictionRepository.java
+++ b/domain/src/main/java/com/whyitrose/domain/prediction/PredictionRepository.java
@@ -1,0 +1,20 @@
+package com.whyitrose.domain.prediction;
+
+import com.whyitrose.domain.common.Status;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PredictionRepository extends JpaRepository<Prediction, Long> {
+
+    Optional<Prediction> findByUserIdAndNotificationIdAndStockId(
+            Long userId, Long notificationId, Long stockId);
+
+    // idx_predictions_user 활용
+    List<Prediction> findByUserIdAndStatusOrderByCreatedAtDesc(Long userId, Status status, Pageable pageable);
+
+    // 복기 미완료 — 배치용
+    List<Prediction> findByActualChangePctIsNullAndStatus(Status status);
+}

--- a/domain/src/main/java/com/whyitrose/domain/scrap/Scrap.java
+++ b/domain/src/main/java/com/whyitrose/domain/scrap/Scrap.java
@@ -1,0 +1,55 @@
+package com.whyitrose.domain.scrap;
+
+import com.whyitrose.domain.common.BaseTimeEntity;
+import com.whyitrose.domain.common.Status;
+import com.whyitrose.domain.event.Event;
+import com.whyitrose.domain.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "scraps",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_scraps", columnNames = {"user_id", "event_id"})
+        },
+        indexes = {
+                @Index(name = "idx_scraps_user", columnList = "user_id, created_at DESC")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Scrap extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "event_id", nullable = false)
+    private Event event;
+
+    // DEFAULT 'ACTIVE'
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private Status status;
+
+    public static Scrap create(User user, Event event) {
+        Scrap scrap = new Scrap();
+        scrap.user = user;
+        scrap.event = event;
+        scrap.status = Status.ACTIVE;
+        return scrap;
+    }
+
+    public void delete() {
+        this.status = Status.DELETED;
+    }
+}

--- a/domain/src/main/java/com/whyitrose/domain/scrap/ScrapRepository.java
+++ b/domain/src/main/java/com/whyitrose/domain/scrap/ScrapRepository.java
@@ -1,0 +1,16 @@
+package com.whyitrose.domain.scrap;
+
+import com.whyitrose.domain.common.Status;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ScrapRepository extends JpaRepository<Scrap, Long> {
+
+    Optional<Scrap> findByUserIdAndEventId(Long userId, Long eventId);
+
+    // idx_scraps_user 활용 — created_at DESC 정렬
+    List<Scrap> findByUserIdAndStatusOrderByCreatedAtDesc(Long userId, Status status, Pageable pageable);
+}

--- a/domain/src/main/java/com/whyitrose/domain/stock/Stock.java
+++ b/domain/src/main/java/com/whyitrose/domain/stock/Stock.java
@@ -1,0 +1,79 @@
+package com.whyitrose.domain.stock;
+
+import com.whyitrose.domain.common.BaseTimeEntity;
+import com.whyitrose.domain.common.Status;
+import com.whyitrose.domain.event.Event;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(
+        name = "stocks",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_stocks_ticker", columnNames = {"ticker"})
+        },
+        indexes = {
+                @Index(name = "idx_stocks_name", columnList = "name"),
+                @Index(name = "idx_stocks_status", columnList = "status")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Stock extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    // 종목코드 ex) 005930
+    @Column(name = "ticker", length = 20, nullable = false)
+    private String ticker;
+
+    // 종목명 ex) 삼성전자
+    @Column(name = "name", length = 100, nullable = false)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "market", length = 20, nullable = false)
+    private StockMarket market;
+
+    @Column(name = "sector", length = 100)
+    private String sector;
+
+    @Column(name = "logo_url", length = 500)
+    private String logoUrl;
+
+    // DEFAULT 'ACTIVE'
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private Status status;
+
+    @OneToMany(mappedBy = "stock", fetch = FetchType.LAZY)
+    private List<Event> events = new ArrayList<>();
+
+    public static Stock create(String ticker, String name, StockMarket market,
+                               String sector, String logoUrl) {
+        Stock stock = new Stock();
+        stock.ticker = ticker;
+        stock.name = name;
+        stock.market = market;
+        stock.sector = sector;
+        stock.logoUrl = logoUrl;
+        stock.status = Status.ACTIVE;
+        return stock;
+    }
+
+    public void deactivate() {
+        this.status = Status.INACTIVE;
+    }
+
+    public void delete() {
+        this.status = Status.DELETED;
+    }
+}

--- a/domain/src/main/java/com/whyitrose/domain/stock/StockMarket.java
+++ b/domain/src/main/java/com/whyitrose/domain/stock/StockMarket.java
@@ -1,0 +1,15 @@
+package com.whyitrose.domain.stock;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum StockMarket {
+
+    KOSPI("코스피"),
+    KOSDAQ("코스닥"),
+    KONEX("코넥스");
+
+    private final String description;
+}

--- a/domain/src/main/java/com/whyitrose/domain/stock/StockPrice.java
+++ b/domain/src/main/java/com/whyitrose/domain/stock/StockPrice.java
@@ -1,0 +1,82 @@
+package com.whyitrose.domain.stock;
+
+import com.whyitrose.domain.common.BaseTimeEntity;
+import com.whyitrose.domain.common.Status;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(
+        name = "stock_prices",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_stock_prices", columnNames = {"stock_id", "trading_date"})
+        },
+        indexes = {
+                @Index(name = "idx_stock_prices_date", columnList = "stock_id, trading_date")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StockPrice extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "stock_id", nullable = false)
+    private Stock stock;
+
+    // 거래일
+    @Column(name = "trading_date", nullable = false)
+    private LocalDate tradingDate;
+
+    // 시가
+    @Column(name = "open_price", nullable = false)
+    private int openPrice;
+
+    // 종가
+    @Column(name = "close_price", nullable = false)
+    private int closePrice;
+
+    // 고가
+    @Column(name = "high_price", nullable = false)
+    private int highPrice;
+
+    // 저가
+    @Column(name = "low_price", nullable = false)
+    private int lowPrice;
+
+    // 거래량
+    @Column(name = "volume", nullable = false)
+    private long volume;
+
+    // DEFAULT 'ACTIVE'
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private Status status;
+
+    public static StockPrice create(Stock stock, LocalDate tradingDate,
+                                    int openPrice, int closePrice,
+                                    int highPrice, int lowPrice, long volume) {
+        StockPrice stockPrice = new StockPrice();
+        stockPrice.stock = stock;
+        stockPrice.tradingDate = tradingDate;
+        stockPrice.openPrice = openPrice;
+        stockPrice.closePrice = closePrice;
+        stockPrice.highPrice = highPrice;
+        stockPrice.lowPrice = lowPrice;
+        stockPrice.volume = volume;
+        stockPrice.status = Status.ACTIVE;
+        return stockPrice;
+    }
+
+    public void delete() {
+        this.status = Status.DELETED;
+    }
+}

--- a/domain/src/main/java/com/whyitrose/domain/stock/StockPriceRepository.java
+++ b/domain/src/main/java/com/whyitrose/domain/stock/StockPriceRepository.java
@@ -1,0 +1,15 @@
+package com.whyitrose.domain.stock;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface StockPriceRepository extends JpaRepository<StockPrice, Long> {
+
+    Optional<StockPrice> findByStockIdAndTradingDate(Long stockId, LocalDate tradingDate);
+
+    List<StockPrice> findByStockIdAndTradingDateBetweenOrderByTradingDateAsc(
+            Long stockId, LocalDate from, LocalDate to);
+}

--- a/domain/src/main/java/com/whyitrose/domain/stock/StockRepository.java
+++ b/domain/src/main/java/com/whyitrose/domain/stock/StockRepository.java
@@ -1,0 +1,16 @@
+package com.whyitrose.domain.stock;
+
+import com.whyitrose.domain.common.Status;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface StockRepository extends JpaRepository<Stock, Long> {
+
+    Optional<Stock> findByTicker(String ticker);
+
+    List<Stock> findByStatus(Status status);
+
+    boolean existsByTicker(String ticker);
+}

--- a/domain/src/main/java/com/whyitrose/domain/user/AuthProvider.java
+++ b/domain/src/main/java/com/whyitrose/domain/user/AuthProvider.java
@@ -1,0 +1,16 @@
+package com.whyitrose.domain.user;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthProvider {
+
+    EMAIL("이메일"),
+    KAKAO("카카오"),
+    NAVER("네이버"),
+    GOOGLE("구글");
+
+    private final String description;
+}

--- a/domain/src/main/java/com/whyitrose/domain/user/User.java
+++ b/domain/src/main/java/com/whyitrose/domain/user/User.java
@@ -1,0 +1,94 @@
+package com.whyitrose.domain.user;
+
+import com.whyitrose.domain.common.BaseTimeEntity;
+import com.whyitrose.domain.common.Status;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "users",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_users_email", columnNames = {"email"}),
+                @UniqueConstraint(name = "uq_users_provider", columnNames = {"provider", "provider_uid"})
+        },
+        indexes = {
+                @Index(name = "idx_users_status", columnList = "status")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    // 소셜 전용이면 null
+    @Column(name = "email", length = 255)
+    private String email;
+
+    // 소셜 전용이면 null
+    @Column(name = "password_hash", length = 255)
+    private String passwordHash;
+
+    @Column(name = "name", length = 100)
+    private String name;
+
+    @Column(name = "nickname", length = 50, nullable = false)
+    private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "provider", length = 20, nullable = false)
+    private AuthProvider provider;
+
+    // 이메일 가입이면 null
+    @Column(name = "provider_uid", length = 255)
+    private String providerUid;
+
+    // DEFAULT 1
+    @Column(name = "push_enabled", nullable = false)
+    private boolean pushEnabled;
+
+    // DEFAULT 0
+    @Column(name = "marketing_agreed", nullable = false)
+    private boolean marketingAgreed;
+
+    // DEFAULT 'ACTIVE'
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private Status status;
+
+    public static User create(String email, String passwordHash, String nickname,
+                              AuthProvider provider, String providerUid) {
+        User user = new User();
+        user.email = email;
+        user.passwordHash = passwordHash;
+        user.nickname = nickname;
+        user.provider = provider;
+        user.providerUid = providerUid;
+        user.pushEnabled = true;
+        user.marketingAgreed = false;
+        user.status = Status.ACTIVE;
+        return user;
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updatePushEnabled(boolean pushEnabled) {
+        this.pushEnabled = pushEnabled;
+    }
+
+    public void deactivate() {
+        this.status = Status.INACTIVE;
+    }
+
+    public void delete() {
+        this.status = Status.DELETED;
+    }
+}

--- a/domain/src/main/java/com/whyitrose/domain/user/UserRepository.java
+++ b/domain/src/main/java/com/whyitrose/domain/user/UserRepository.java
@@ -1,0 +1,15 @@
+package com.whyitrose.domain.user;
+
+import com.whyitrose.domain.common.Status;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+
+    Optional<User> findByProviderAndProviderUid(AuthProvider provider, String providerUid);
+
+    boolean existsByEmail(String email);
+}


### PR DESCRIPTION
 ## #️⃣Issue Number
  - Closes #4

  ## 📝 변경사항

  ### 🎯 핵심 변경 사항 (Key Changes)

  - [x] DDL 기반 JPA 엔티티 17개 설계 및 생성 (`User`, `Stock`, `StockPrice`, `Event`, `EventNews`, `News`, `NewsStock`, `Tag`, `NewsTag`, `Scrap`, `Memo`, `DailyNewsDigest`,
  `DailyNewsDigestItem`, `Notification`, `NotificationLog`, `Prediction`, `InterestStock`)
  - [x] 도메인별 Spring Data JPA Repository 인터페이스 17개 생성

  ### 🔍 주안점 & 리뷰 포인트

  - `BaseTimeEntity`: `createdAt(updatable=false)` / `updatedAt(insertable=false)` — INSERT는 DB DEFAULT, UPDATE는 JPA Auditing이 처리합니다.
  - `Status` Enum 단일화: `PENDING | ACTIVE | INACTIVE | DELETED` 4개 값으로 전 테이블 통일했습니다. 도메인별로 쪼개는 방식 대신 단순함을 택했는데 방향이 맞는지 봐주세요.
  - 모든 `@ManyToOne`에 `FetchType.LAZY` 강제 적용, `@ManyToMany` 미사용 — N:M은 전부 중간 엔티티로 해소했습니다.
  - 양방향 관계 (`Stock↔Event`, `Event↔EventNews`, `News↔NewsStock`, `DailyNewsDigest↔Item`, `Notification↔NotificationLog`)에 연관관계 편의 메서드를 주인(Many) 쪽에 작성했습니다.
  - `cascade` 미설정 — 엔티티 간 생명주기가 독립적이라 판단했습니다.
  - Repository 쿼리 메서드는 DDL 인덱스 컬럼 기준으로만 선언했습니다.

  ### 🖼️스크린샷 / 테스트 결과

  ▎ Task :core:compileJava
  ▎ Task :domain:compileJava
  ▎ Task :api-server:compileJava

  BUILD SUCCESSFUL

  ---

  ## 🛠️PR 유형
  - [x] ✨ 새로운 기능 추가

  ## 🧪 영향 범위 및 테스트

  ### **영향을 받는 모듈/컴포넌트:**
  `domain`, `api-server` (`@EnableJpaAuditing` 추가)

  ### **테스트 방법:**
  - [ ] 단위 테스트 (JUnit/Jest)
  - [ ] 통합 테스트
  - [ ] 수동 API 테스트 (Postman/Swagger)

  ## ✅ PR Checklist
  - [x] 커밋 메시지 컨벤션을 준수했습니다.
  - [x] 불필요한 로그나 주석을 제거했습니다.
  - [x] 관련 이슈를 연결했습니다.