### PR TITLE
[Feat] stock list

### DIFF
--- a/api-server/src/main/java/com/whyitrose/apiserver/config/SecurityConfig.java
+++ b/api-server/src/main/java/com/whyitrose/apiserver/config/SecurityConfig.java
@@ -61,7 +61,8 @@ public class SecurityConfig {
                                 "/auth/refresh",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
-                                "/actuator/health"
+                                "/actuator/health",
+                                "/api/stocks/**"
                                 ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/api-server/src/main/java/com/whyitrose/apiserver/stock/controller/StockController.java
+++ b/api-server/src/main/java/com/whyitrose/apiserver/stock/controller/StockController.java
@@ -1,0 +1,56 @@
+package com.whyitrose.apiserver.stock.controller;
+
+import com.whyitrose.apiserver.stock.dto.StockDtos.StockDetailResponse;
+import com.whyitrose.apiserver.stock.dto.StockDtos.StockListResponse;
+import com.whyitrose.apiserver.stock.dto.StockDtos.StockPricesResponse;
+import com.whyitrose.apiserver.stock.dto.StockDtos.StockSearchResponse;
+import com.whyitrose.apiserver.stock.service.StockService;
+import com.whyitrose.core.response.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/stocks")
+public class StockController {
+
+    private final StockService stockService;
+
+    @GetMapping
+    public ResponseEntity<BaseResponse<StockListResponse>> getStocks(
+            @RequestParam(defaultValue = "ALL") String market,
+            @RequestParam(defaultValue = "TRADING_AMOUNT") String sort,
+            @RequestParam(defaultValue = "1D") String period,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(defaultValue = "20") Integer size
+    ) {
+        return ResponseEntity.ok(BaseResponse.success(
+                stockService.getStocks(market, sort, period, cursor, size)));
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<BaseResponse<StockSearchResponse>> search(
+            @RequestParam("q") String q,
+            @RequestParam(defaultValue = "10") Integer limit
+    ) {
+        return ResponseEntity.ok(BaseResponse.success(stockService.searchStocks(q, limit)));
+    }
+
+    @GetMapping("/{stockId}")
+    public ResponseEntity<BaseResponse<StockDetailResponse>> getStockDetail(@PathVariable Long stockId) {
+        return ResponseEntity.ok(BaseResponse.success(stockService.getStockDetail(stockId)));
+    }
+
+    @GetMapping("/{stockId}/prices")
+    public ResponseEntity<BaseResponse<StockPricesResponse>> getStockPrices(
+            @PathVariable Long stockId,
+            @RequestParam(defaultValue = "6M") String period
+    ) {
+        return ResponseEntity.ok(BaseResponse.success(stockService.getStockPrices(stockId, period)));
+    }
+}

--- a/api-server/src/main/java/com/whyitrose/apiserver/stock/dto/StockDtos.java
+++ b/api-server/src/main/java/com/whyitrose/apiserver/stock/dto/StockDtos.java
@@ -1,0 +1,104 @@
+package com.whyitrose.apiserver.stock.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class StockDtos {
+
+    public enum ChangeDirection {
+        UP, DOWN, FLAT
+    }
+
+    public record StockListResponse(
+            String nextCursor,
+            boolean hasNext,
+            int size,
+            List<StockListItem> items
+    ) {}
+
+    public record StockListItem(
+            int rank,
+            Long stockId,
+            String ticker,
+            String name,
+            String market,
+            String logoUrl,
+            long currentPrice,
+            long priceChange,
+            double changeRate,
+            ChangeDirection changeDirection,
+            long tradingAmount,
+            long tradingVolume,
+            boolean hasEvent,
+            String eventType,
+            boolean isInterested
+    ) {}
+
+    public record StockSearchResponse(
+            String query,
+            int totalCount,
+            List<StockSearchItem> items
+    ) {}
+
+    public record StockSearchItem(
+            Long stockId,
+            String ticker,
+            String name,
+            String market,
+            String logoUrl,
+            long currentPrice,
+            double changeRate,
+            ChangeDirection changeDirection
+    ) {}
+
+    public record StockDetailResponse(
+            Long stockId,
+            String ticker,
+            String name,
+            String market,
+            String sector,
+            String logoUrl,
+            long currentPrice,
+            long priceChange,
+            double changeRate,
+            ChangeDirection changeDirection,
+            TodayOhlcv todayOhlcv,
+            boolean isInterested
+    ) {}
+
+    public record TodayOhlcv(
+            long open,
+            long high,
+            long low,
+            long volume
+    ) {}
+
+    public record StockPricesResponse(
+            Long stockId,
+            String period,
+            List<CandleDto> candles,
+            List<EventPinDto> eventPins,
+            List<NewsPinDto> newsPins
+    ) {}
+
+    public record CandleDto(
+            LocalDate date,
+            long open,
+            long close,
+            long high,
+            long low,
+            long volume
+    ) {}
+
+    public record EventPinDto(
+            Long eventId,
+            LocalDate date,
+            String eventType,
+            double changeRate
+    ) {}
+
+    public record NewsPinDto(
+            LocalDate date,
+            int newsCount
+    ) {}
+}

--- a/api-server/src/main/java/com/whyitrose/apiserver/stock/exception/StockErrorCode.java
+++ b/api-server/src/main/java/com/whyitrose/apiserver/stock/exception/StockErrorCode.java
@@ -1,0 +1,21 @@
+package com.whyitrose.apiserver.stock.exception;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.whyitrose.core.response.ResponseStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum StockErrorCode implements ResponseStatus {
+    STOCK_001(false, HttpStatus.NOT_FOUND, 4101, "존재하지 않는 종목입니다."),
+    STOCK_002(false, HttpStatus.NOT_FOUND, 4102, "해당 기간의 차트 데이터가 없습니다."),
+    STOCK_004(false, HttpStatus.BAD_REQUEST, 4104, "검색어는 1자 이상이어야 합니다.");
+
+    private final boolean isSuccess;
+    @JsonIgnore
+    private final HttpStatus httpStatus;
+    private final int responseCode;
+    private final String responseMessage;
+}

--- a/api-server/src/main/java/com/whyitrose/apiserver/stock/service/StockService.java
+++ b/api-server/src/main/java/com/whyitrose/apiserver/stock/service/StockService.java
@@ -1,0 +1,313 @@
+package com.whyitrose.apiserver.stock.service;
+
+import com.whyitrose.apiserver.stock.dto.StockDtos.CandleDto;
+import com.whyitrose.apiserver.stock.dto.StockDtos.ChangeDirection;
+import com.whyitrose.apiserver.stock.dto.StockDtos.StockDetailResponse;
+import com.whyitrose.apiserver.stock.dto.StockDtos.StockListItem;
+import com.whyitrose.apiserver.stock.dto.StockDtos.StockListResponse;
+import com.whyitrose.apiserver.stock.dto.StockDtos.StockPricesResponse;
+import com.whyitrose.apiserver.stock.dto.StockDtos.StockSearchItem;
+import com.whyitrose.apiserver.stock.dto.StockDtos.StockSearchResponse;
+import com.whyitrose.apiserver.stock.dto.StockDtos.TodayOhlcv;
+import com.whyitrose.apiserver.stock.exception.StockErrorCode;
+import com.whyitrose.core.exception.BaseException;
+import com.whyitrose.domain.common.Status;
+import com.whyitrose.domain.stock.Stock;
+import com.whyitrose.domain.stock.StockPrice;
+import com.whyitrose.domain.stock.StockPricePeriod;
+import com.whyitrose.domain.stock.StockPriceRepository;
+import com.whyitrose.domain.stock.StockRepository;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StockService {
+
+    private final StockRepository stockRepository;
+    private final StockPriceRepository stockPriceRepository;
+
+    public StockListResponse getStocks(String market, String sort, String period, String cursor, Integer size) {
+        int pageSize = Math.max(1, Math.min(size == null ? 20 : size, 100));
+        int offset = parseCursor(cursor);
+        List<Stock> stocks = stockRepository.findByStatusOrderByIdAsc(Status.ACTIVE);
+        if (market != null && !"ALL".equalsIgnoreCase(market)) {
+            stocks = stocks.stream()
+                    .filter(s -> s.getMarket().name().equalsIgnoreCase(market))
+                    .toList();
+        }
+
+        List<StockListItem> allItems = new ArrayList<>();
+        for (Stock stock : stocks) {
+            PriceSnapshot snapshot = latestSnapshot(stock.getId(), period);
+            allItems.add(new StockListItem(
+                    0,
+                    stock.getId(),
+                    stock.getTicker(),
+                    stock.getName(),
+                    stock.getMarket().name(),
+                    stock.getLogoUrl(),
+                    snapshot.currentPrice,
+                    snapshot.priceChange,
+                    snapshot.changeRate,
+                    snapshot.direction,
+                    snapshot.tradingAmount,
+                    snapshot.tradingVolume,
+                    false,
+                    null,
+                    false
+            ));
+        }
+
+        allItems.sort(stockComparator(sort));
+        if (offset < 0 || offset > allItems.size()) {
+            offset = 0;
+        }
+        int endExclusive = Math.min(allItems.size(), offset + pageSize);
+        List<StockListItem> content = allItems.subList(offset, endExclusive);
+        boolean hasNext = endExclusive < allItems.size();
+        List<StockListItem> ranked = new ArrayList<>();
+        int rank = offset + 1;
+        for (StockListItem item : content) {
+            ranked.add(new StockListItem(
+                    rank++,
+                    item.stockId(),
+                    item.ticker(),
+                    item.name(),
+                    item.market(),
+                    item.logoUrl(),
+                    item.currentPrice(),
+                    item.priceChange(),
+                    item.changeRate(),
+                    item.changeDirection(),
+                    item.tradingAmount(),
+                    item.tradingVolume(),
+                    item.hasEvent(),
+                    item.eventType(),
+                    item.isInterested()
+            ));
+        }
+
+        String nextCursor = hasNext ? String.valueOf(endExclusive) : null;
+        return new StockListResponse(nextCursor, hasNext, ranked.size(), ranked);
+    }
+
+    public StockSearchResponse searchStocks(String query, Integer limit) {
+        if (query == null || query.trim().isBlank()) {
+            throw new BaseException(StockErrorCode.STOCK_004);
+        }
+        String q = query.trim();
+        int size = Math.max(1, Math.min(limit == null ? 10 : limit, 20));
+        List<Stock> tickerMatches = stockRepository.findByStatusAndTickerContainingIgnoreCaseOrderByIdAsc(
+                Status.ACTIVE, q, PageRequest.of(0, size));
+        List<Stock> nameMatches = stockRepository.findByStatusAndNameContainingIgnoreCaseOrderByIdAsc(
+                Status.ACTIVE, q, PageRequest.of(0, size));
+
+        Map<Long, Stock> dedup = new LinkedHashMap<>();
+        for (Stock stock : tickerMatches) {
+            dedup.put(stock.getId(), stock);
+        }
+        for (Stock stock : nameMatches) {
+            dedup.put(stock.getId(), stock);
+        }
+
+        List<StockSearchItem> items = dedup.values().stream()
+                .limit(size)
+                .map(stock -> {
+                    PriceSnapshot snapshot = latestSnapshot(stock.getId(), "1D");
+                    return new StockSearchItem(
+                            stock.getId(),
+                            stock.getTicker(),
+                            stock.getName(),
+                            stock.getMarket().name(),
+                            stock.getLogoUrl(),
+                            snapshot.currentPrice,
+                            snapshot.changeRate,
+                            snapshot.direction
+                    );
+                })
+                .toList();
+
+        return new StockSearchResponse(q, items.size(), items);
+    }
+
+    public StockDetailResponse getStockDetail(Long stockId) {
+        Stock stock = stockRepository.findById(stockId)
+                .orElseThrow(() -> new BaseException(StockErrorCode.STOCK_001));
+        PriceSnapshot snapshot = latestSnapshot(stockId, "1D");
+        StockPrice latestDaily = stockPriceRepository.findTopByStockIdAndPeriodOrderByTradingDateDesc(
+                        stockId, StockPricePeriod.DAILY)
+                .orElse(null);
+
+        TodayOhlcv ohlcv = new TodayOhlcv(
+                latestDaily == null ? 0 : latestDaily.getOpenPrice(),
+                latestDaily == null ? 0 : latestDaily.getHighPrice(),
+                latestDaily == null ? 0 : latestDaily.getLowPrice(),
+                latestDaily == null ? 0 : latestDaily.getVolume()
+        );
+
+        return new StockDetailResponse(
+                stock.getId(),
+                stock.getTicker(),
+                stock.getName(),
+                stock.getMarket().name(),
+                stock.getSector(),
+                stock.getLogoUrl(),
+                snapshot.currentPrice,
+                snapshot.priceChange,
+                snapshot.changeRate,
+                snapshot.direction,
+                ohlcv,
+                false
+        );
+    }
+
+    public StockPricesResponse getStockPrices(Long stockId, String period) {
+        Stock stock = stockRepository.findById(stockId)
+                .orElseThrow(() -> new BaseException(StockErrorCode.STOCK_001));
+        String key = normalizePeriod(period);
+        StockPricePeriod mappedPeriod = resolvePricePeriod(key);
+        int fetchSize = resolveFetchSize(key);
+        List<StockPrice> desc = stockPriceRepository.findByStockIdAndPeriodOrderByTradingDateDesc(
+                stock.getId(), mappedPeriod, PageRequest.of(0, fetchSize));
+        List<StockPrice> prices = desc.stream()
+                .sorted(Comparator.comparing(StockPrice::getTradingDate))
+                .toList();
+        if (prices.isEmpty()) {
+            throw new BaseException(StockErrorCode.STOCK_002);
+        }
+        List<CandleDto> candles = prices.stream()
+                .map(price -> new CandleDto(
+                        price.getTradingDate(),
+                        price.getOpenPrice(),
+                        price.getClosePrice(),
+                        price.getHighPrice(),
+                        price.getLowPrice(),
+                        price.getVolume()
+                ))
+                .toList();
+
+        return new StockPricesResponse(stock.getId(), key, candles, List.of(), List.of());
+    }
+
+    private PriceSnapshot latestSnapshot(Long stockId, String period) {
+        String key = normalizePeriod(period);
+        StockPricePeriod mappedPeriod = resolvePricePeriod(key);
+        int tradingDays = resolveTradingDays(key);
+        List<StockPrice> desc = stockPriceRepository.findByStockIdAndPeriodOrderByTradingDateDesc(
+                stockId, mappedPeriod, PageRequest.of(0, Math.max(2, tradingDays + 1)));
+        if (desc.isEmpty()) {
+            return new PriceSnapshot(0, 0, 0.0, ChangeDirection.FLAT, 0, 0);
+        }
+        StockPrice current = desc.get(0);
+        StockPrice previous = desc.size() > tradingDays ? desc.get(tradingDays) : desc.get(desc.size() - 1);
+
+        long currentPrice = current.getClosePrice();
+        long previousPrice = previous == null ? currentPrice : previous.getClosePrice();
+        long change = currentPrice - previousPrice;
+        double rate = previousPrice == 0 ? 0.0 : ((double) change / previousPrice) * 100.0;
+        ChangeDirection direction = change > 0 ? ChangeDirection.UP : (change < 0 ? ChangeDirection.DOWN : ChangeDirection.FLAT);
+        int windowSize = Math.max(1, Math.min(tradingDays, desc.size()));
+        long tradingVolume = 0L;
+        long tradingAmount = 0L;
+        for (int i = 0; i < windowSize; i++) {
+            StockPrice price = desc.get(i);
+            tradingVolume += price.getVolume();
+            tradingAmount += (long) price.getClosePrice() * price.getVolume();
+        }
+
+        return new PriceSnapshot(currentPrice, change, round2(rate), direction, tradingAmount, tradingVolume);
+    }
+
+    private Comparator<StockListItem> stockComparator(String sort) {
+        String key = sort == null ? "TRADING_AMOUNT" : sort.toUpperCase(Locale.ROOT);
+        return switch (key) {
+            case "TRADING_VOLUME" -> Comparator.comparingLong(StockListItem::tradingVolume).reversed()
+                    .thenComparingLong(StockListItem::stockId);
+            case "SURGE" -> Comparator.comparingDouble(StockListItem::changeRate).reversed()
+                    .thenComparingLong(StockListItem::stockId);
+            case "DROP" -> Comparator.comparingDouble(StockListItem::changeRate)
+                    .thenComparingLong(StockListItem::stockId);
+            default -> Comparator.comparingLong(StockListItem::tradingAmount).reversed()
+                    .thenComparingLong(StockListItem::stockId);
+        };
+    }
+
+    private int parseCursor(String cursor) {
+        if (cursor == null || cursor.isBlank()) {
+            return 0;
+        }
+        try {
+            return Integer.parseInt(cursor);
+        } catch (NumberFormatException ignored) {
+            return 0;
+        }
+    }
+
+    private String normalizePeriod(String period) {
+        if (period == null || period.isBlank()) {
+            return "6M";
+        }
+        String key = period.toUpperCase(Locale.ROOT);
+        return switch (key) {
+            case "REALTIME", "1D", "1W", "1M", "3M", "6M", "1Y" -> key;
+            default -> "6M";
+        };
+    }
+
+    private int resolveTradingDays(String period) {
+        String key = normalizePeriod(period);
+        return switch (key) {
+            case "REALTIME", "1D" -> 1;
+            case "1W", "1M", "1Y" -> 1;
+            case "3M" -> 60;
+            case "6M" -> 120;
+            default -> 120;
+        };
+    }
+
+    private StockPricePeriod resolvePricePeriod(String period) {
+        String key = normalizePeriod(period);
+        return switch (key) {
+            case "1W" -> StockPricePeriod.WEEKLY;
+            case "1M" -> StockPricePeriod.MONTHLY;
+            case "1Y" -> StockPricePeriod.YEARLY;
+            default -> StockPricePeriod.DAILY;
+        };
+    }
+
+    private int resolveFetchSize(String period) {
+        String key = normalizePeriod(period);
+        return switch (key) {
+            case "1W" -> 52;
+            case "1M" -> 60;
+            case "1Y" -> 20;
+            case "3M" -> 60;
+            case "6M" -> 120;
+            default -> 120;
+        };
+    }
+
+    private double round2(double value) {
+        return Math.round(value * 100.0) / 100.0;
+    }
+
+    private record PriceSnapshot(
+            long currentPrice,
+            long priceChange,
+            double changeRate,
+            ChangeDirection direction,
+            long tradingAmount,
+            long tradingVolume
+    ) {}
+}

--- a/domain/src/main/java/com/whyitrose/domain/stock/StockPriceRepository.java
+++ b/domain/src/main/java/com/whyitrose/domain/stock/StockPriceRepository.java
@@ -22,8 +22,23 @@ public interface StockPriceRepository extends JpaRepository<StockPrice, Long> {
     Optional<StockPrice> findByStockIdAndTradingDateAndPeriod(
             Long stockId, LocalDate tradingDate, StockPricePeriod period);
 
+    Optional<StockPrice> findTopByStockIdAndPeriodOrderByTradingDateDesc(
+            Long stockId, StockPricePeriod period);
+
+    List<StockPrice> findTop2ByStockIdAndPeriodOrderByTradingDateDesc(
+            Long stockId, StockPricePeriod period);
+
+    Optional<StockPrice> findTopByStockIdAndPeriodAndTradingDateLessThanEqualOrderByTradingDateDesc(
+            Long stockId, StockPricePeriod period, LocalDate tradingDate);
+
     List<StockPrice> findByStockIdAndTradingDateBetweenOrderByTradingDateAsc(
             Long stockId, LocalDate from, LocalDate to);
+
+    List<StockPrice> findByStockIdAndPeriodAndTradingDateBetweenOrderByTradingDateAsc(
+            Long stockId, StockPricePeriod period, LocalDate from, LocalDate to);
+
+    List<StockPrice> findByStockIdAndPeriodOrderByTradingDateDesc(
+            Long stockId, StockPricePeriod period, Pageable pageable);
 
     // 특정 종목의 전체 주가를 날짜 오름차순 조회
     List<StockPrice> findByStockIdOrderByTradingDateAsc(Long stockId);

--- a/domain/src/main/java/com/whyitrose/domain/stock/StockRepository.java
+++ b/domain/src/main/java/com/whyitrose/domain/stock/StockRepository.java
@@ -2,6 +2,7 @@ package com.whyitrose.domain.stock;
 
 import com.whyitrose.domain.common.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Pageable;
 import java.util.List;
 import java.util.Optional;
 
@@ -11,6 +12,8 @@ public interface StockRepository extends JpaRepository<Stock, Long> {
 
     List<Stock> findByStatus(Status status);
     List<Stock> findByStatusOrderByIdAsc(Status status);
+    List<Stock> findByStatusAndTickerContainingIgnoreCaseOrderByIdAsc(Status status, String ticker, Pageable pageable);
+    List<Stock> findByStatusAndNameContainingIgnoreCaseOrderByIdAsc(Status status, String name, Pageable pageable);
 
     boolean existsByTicker(String ticker);
 }


### PR DESCRIPTION
## #️⃣ Issue Number
- Closes #60 

## 📝 변경사항

Stock 도메인 API를 `api-server`에 신규 구현하고, 프론트 연동 중 발견된 기간/정렬/페이지네이션 이슈를 수정했습니다.  
특히 기간별 데이터 해석(`1D/1W/1M/1Y`)과 순위 페이징 일관성을 맞춰 실제 화면 동작을 안정화했습니다.

### 🎯 핵심 변경 사항 (Key Changes)

- [x] `api-server`에 Stock API 신규 구현
  - `GET /api/stocks`
  - `GET /api/stocks/search`
  - `GET /api/stocks/{stockId}`
  - `GET /api/stocks/{stockId}/prices`
- [x] Stock DTO/Service/Controller/에러코드(`StockErrorCode`) 추가
- [x] `domain` 조회 메서드 확장
  - `StockRepository` 검색/정렬 메서드 추가
  - `StockPriceRepository` 최신봉/기간조회 메서드 추가
- [x] 리스트 순위/커서 로직 보정
  - 페이지 이동 시 rank가 1부터 초기화되던 문제 수정
  - 정렬 기준과 커서 기준 불일치로 순번이 튀던 문제 수정(오프셋 기반)
- [x] 기간 매핑/계산 보정
  - `1D -> DAILY`, `1W -> WEEKLY`, `1M -> MONTHLY`, `1Y -> YEARLY`
  - `tradingVolume`, `tradingAmount`가 기간에 따라 실제 집계값으로 변경되도록 수정

### 🔍 주안점 & 리뷰 포인트

- `/api/stocks`의 `cursor`는 현재 **offset 기반 문자열**입니다. 프론트가 `nextCursor`를 그대로 전달하는 방식과 일치하는지 확인 부탁드립니다.
- `1W/1M/1Y`는 현재 주기봉(`WEEKLY/MONTHLY/YEARLY`) 최신/직전 봉 비교 기반입니다.
- `3M/6M` 정책은 추후 확정 필요(현재 DAILY 기반 누적 집계 로직 유지).

### 🖼️ 스크린샷 / 테스트 결과 (선택 사항)

- 로컬 컴파일 성공
  - `:api-server:compileJava`
  - `:domain:compileJava`
- 스웨거/수동 호출로 Stock 주요 엔드포인트 응답 확인

---

## 🛠️ PR 유형
- [x] ✨ 새로운 기능 추가
- [x] 🐛 버그 수정
- [ ] 💄 UI/UX 디자인 변경
- [x] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## 🧪 영향 범위 및 테스트 (Impact & Tests)

### **영향을 받는 모듈/컴포넌트:**
- `api-server` (`stock` controller/service/dto/exception)
- `domain` (`StockRepository`, `StockPriceRepository`)

### **테스트 방법:**
- [ ] 단위 테스트 (JUnit/Jest)
- [ ] 통합 테스트
- [x] 수동 API 테스트 (Postman/Swagger)

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 불필요한 로그나 주석을 제거했습니다.
- [ ] 관련 이슈를 연결했습니다.
