### PR TITLE
[Feat] 메모 API 구현 및 이벤트 API 추가 구현

### DIFF
--- a/api-server/src/main/java/com/whyitrose/apiserver/event/controller/EventController.java
+++ b/api-server/src/main/java/com/whyitrose/apiserver/event/controller/EventController.java
@@ -4,6 +4,7 @@ import com.whyitrose.apiserver.event.dto.EventDetailResponse;
 import com.whyitrose.apiserver.event.dto.EventDetectRangeRequest;
 import com.whyitrose.apiserver.event.dto.EventDetectRequest;
 import com.whyitrose.apiserver.event.dto.EventResponse;
+import com.whyitrose.apiserver.event.dto.StockLatestEventResponse;
 import com.whyitrose.apiserver.event.service.EventService;
 import com.whyitrose.core.response.BaseResponse;
 import com.whyitrose.domain.event.EventType;
@@ -145,6 +146,37 @@ public class EventController {
     @GetMapping("/{eventId}")
     public ResponseEntity<BaseResponse<EventDetailResponse>> getEventDetail(@PathVariable Long eventId) {
         return ResponseEntity.ok(BaseResponse.success(eventService.getEventDetail(eventId)));
+    }
+
+    @Operation(
+            summary = "종목 목록의 최신 이벤트 조회",
+            description = "여러 종목 ID를 받아 각 종목의 최신 급등/급락 이벤트를 반환합니다. 이벤트가 없는 종목은 결과에 포함되지 않습니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                            {
+                              "isSuccess": true,
+                              "responseCode": 1000,
+                              "responseMessage": "요청에 성공하였습니다.",
+                              "result": [
+                                {
+                                  "stockId": 10,
+                                  "eventId": 1,
+                                  "eventType": "SURGE",
+                                  "startDate": "2024-03-16",
+                                  "endDate": "2024-03-16",
+                                  "changePct": 12.35
+                                }
+                              ]
+                            }
+                            """)))
+    })
+    @GetMapping("/latest")
+    public ResponseEntity<BaseResponse<List<StockLatestEventResponse>>> getLatestEvents(
+            @RequestParam List<Long> stockIds
+    ) {
+        return ResponseEntity.ok(BaseResponse.success(eventService.getLatestEventsByStockIds(stockIds)));
     }
 
     @Operation(

--- a/api-server/src/main/java/com/whyitrose/apiserver/event/dto/StockLatestEventResponse.java
+++ b/api-server/src/main/java/com/whyitrose/apiserver/event/dto/StockLatestEventResponse.java
@@ -1,0 +1,39 @@
+package com.whyitrose.apiserver.event.dto;
+
+import com.whyitrose.domain.event.Event;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Schema(description = "종목별 최신 이벤트 응답")
+public record StockLatestEventResponse(
+        @Schema(description = "종목 ID", example = "10")
+        Long stockId,
+
+        @Schema(description = "이벤트 ID", example = "1")
+        Long eventId,
+
+        @Schema(description = "이벤트 유형", example = "SURGE", allowableValues = {"SURGE", "DROP"})
+        String eventType,
+
+        @Schema(description = "이벤트 시작일", example = "2024-03-16")
+        LocalDate startDate,
+
+        @Schema(description = "이벤트 종료일", example = "2024-03-16")
+        LocalDate endDate,
+
+        @Schema(description = "등락률 (%)", example = "12.35")
+        BigDecimal changePct
+) {
+    public static StockLatestEventResponse from(Event event) {
+        return new StockLatestEventResponse(
+                event.getStock().getId(),
+                event.getId(),
+                event.getEventType().name(),
+                event.getStartDate(),
+                event.getEndDate(),
+                event.getChangePct()
+        );
+    }
+}

--- a/api-server/src/main/java/com/whyitrose/apiserver/event/service/EventService.java
+++ b/api-server/src/main/java/com/whyitrose/apiserver/event/service/EventService.java
@@ -2,6 +2,7 @@ package com.whyitrose.apiserver.event.service;
 
 import com.whyitrose.apiserver.event.dto.EventDetailResponse;
 import com.whyitrose.apiserver.event.dto.EventResponse;
+import com.whyitrose.apiserver.event.dto.StockLatestEventResponse;
 import com.whyitrose.apiserver.event.exception.EventErrorCode;
 import com.whyitrose.core.exception.BaseException;
 import com.whyitrose.domain.common.Status;
@@ -51,6 +52,15 @@ public class EventService {
 
         return events.stream()
                 .map(EventResponse::from)
+                .toList();
+    }
+
+    // ── 종목 목록의 최신 이벤트 조회 ──────────────────────────────────────
+
+    public List<StockLatestEventResponse> getLatestEventsByStockIds(List<Long> stockIds) {
+        return eventRepository.findLatestByStockIds(stockIds, Status.ACTIVE)
+                .stream()
+                .map(StockLatestEventResponse::from)
                 .toList();
     }
 

--- a/api-server/src/main/java/com/whyitrose/apiserver/memo/controller/MemoController.java
+++ b/api-server/src/main/java/com/whyitrose/apiserver/memo/controller/MemoController.java
@@ -1,0 +1,186 @@
+package com.whyitrose.apiserver.memo.controller;
+
+import com.whyitrose.apiserver.memo.dto.MemoCreateRequest;
+import com.whyitrose.apiserver.memo.dto.MemoResponse;
+import com.whyitrose.apiserver.memo.dto.MemoUpdateRequest;
+import com.whyitrose.apiserver.memo.service.MemoService;
+import com.whyitrose.core.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "Memo", description = "메모 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping
+public class MemoController {
+
+    private final MemoService memoService;
+
+    @Operation(
+            summary = "메모 목록 조회",
+            description = "특정 이벤트에 대해 내가 작성한 메모 목록을 최신순으로 반환합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                            {
+                              "isSuccess": true,
+                              "responseCode": 1000,
+                              "responseMessage": "요청에 성공하였습니다.",
+                              "result": [
+                                {
+                                  "memoId": 1,
+                                  "content": "HBM 납품 기대감으로 외국인 매수세가 강하게 불은 구간.",
+                                  "createdAt": "2026-03-16T10:30:00"
+                                }
+                              ]
+                            }
+                            """))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 이벤트",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                            {
+                              "isSuccess": false,
+                              "responseCode": 4011,
+                              "responseMessage": "존재하지 않는 이벤트입니다."
+                            }
+                            """)))
+    })
+    @GetMapping("/events/{eventId}/memos")
+    public ResponseEntity<BaseResponse<List<MemoResponse>>> getMemos(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long eventId
+    ) {
+        return ResponseEntity.ok(BaseResponse.success(memoService.getMemos(userId, eventId)));
+    }
+
+    @Operation(
+            summary = "메모 작성",
+            description = "특정 이벤트에 메모를 작성합니다. 최대 300자까지 입력 가능합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "작성 성공",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                            {
+                              "isSuccess": true,
+                              "responseCode": 1000,
+                              "responseMessage": "요청에 성공하였습니다.",
+                              "result": {
+                                "memoId": 1,
+                                "content": "HBM 납품 기대감으로 외국인 매수세가 강하게 불은 구간.",
+                                "createdAt": "2026-03-16T10:30:00"
+                              }
+                            }
+                            """))),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 (내용 없음 또는 300자 초과)",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                            {
+                              "isSuccess": false,
+                              "responseCode": 2001,
+                              "responseMessage": "요청 파라미터 타입이 올바르지 않습니다."
+                            }
+                            """))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 이벤트",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                            {
+                              "isSuccess": false,
+                              "responseCode": 4011,
+                              "responseMessage": "존재하지 않는 이벤트입니다."
+                            }
+                            """)))
+    })
+    @PostMapping("/events/{eventId}/memos")
+    public ResponseEntity<BaseResponse<MemoResponse>> createMemo(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long eventId,
+            @RequestBody @Valid MemoCreateRequest request
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(BaseResponse.success(memoService.createMemo(userId, eventId, request)));
+    }
+
+    @Operation(
+            summary = "메모 수정",
+            description = "내가 작성한 메모를 수정합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                            {
+                              "isSuccess": true,
+                              "responseCode": 1000,
+                              "responseMessage": "요청에 성공하였습니다.",
+                              "result": {
+                                "memoId": 1,
+                                "content": "수정된 메모 내용입니다.",
+                                "createdAt": "2026-03-16T10:30:00"
+                              }
+                            }
+                            """))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않거나 본인 메모 아님",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                            {
+                              "isSuccess": false,
+                              "responseCode": 4010,
+                              "responseMessage": "존재하지 않는 메모입니다."
+                            }
+                            """)))
+    })
+    @PutMapping("/memos/{memoId}")
+    public ResponseEntity<BaseResponse<MemoResponse>> updateMemo(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long memoId,
+            @RequestBody @Valid MemoUpdateRequest request
+    ) {
+        return ResponseEntity.ok(BaseResponse.success(memoService.updateMemo(userId, memoId, request)));
+    }
+
+    @Operation(
+            summary = "메모 삭제",
+            description = "내가 작성한 메모를 삭제합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                            {
+                              "isSuccess": true,
+                              "responseCode": 1000,
+                              "responseMessage": "요청에 성공하였습니다."
+                            }
+                            """))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않거나 본인 메모 아님",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                            {
+                              "isSuccess": false,
+                              "responseCode": 4010,
+                              "responseMessage": "존재하지 않는 메모입니다."
+                            }
+                            """)))
+    })
+    @DeleteMapping("/memos/{memoId}")
+    public ResponseEntity<BaseResponse<Void>> deleteMemo(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long memoId
+    ) {
+        memoService.deleteMemo(userId, memoId);
+        return ResponseEntity.ok(BaseResponse.success(null));
+    }
+}

--- a/api-server/src/main/java/com/whyitrose/apiserver/memo/dto/MemoCreateRequest.java
+++ b/api-server/src/main/java/com/whyitrose/apiserver/memo/dto/MemoCreateRequest.java
@@ -1,0 +1,15 @@
+package com.whyitrose.apiserver.memo.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "메모 작성 요청")
+public record MemoCreateRequest(
+
+        @Schema(description = "메모 내용 (최대 300자)", example = "HBM 납품 기대감으로 외국인 매수세가 강하게 불은 구간.")
+        @NotBlank(message = "메모 내용을 입력해주세요.")
+        @Size(max = 300, message = "메모는 최대 300자까지 입력 가능합니다.")
+        String content
+) {
+}

--- a/api-server/src/main/java/com/whyitrose/apiserver/memo/dto/MemoResponse.java
+++ b/api-server/src/main/java/com/whyitrose/apiserver/memo/dto/MemoResponse.java
@@ -1,0 +1,27 @@
+package com.whyitrose.apiserver.memo.dto;
+
+import com.whyitrose.domain.memo.Memo;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "메모 응답")
+public record MemoResponse(
+
+        @Schema(description = "메모 ID", example = "1")
+        Long memoId,
+
+        @Schema(description = "메모 내용", example = "HBM 납품 기대감으로 외국인 매수세가 강하게 불은 구간.")
+        String content,
+
+        @Schema(description = "작성 일시", example = "2026-03-16T10:30:00")
+        LocalDateTime createdAt
+) {
+    public static MemoResponse from(Memo memo) {
+        return new MemoResponse(
+                memo.getId(),
+                memo.getContent(),
+                memo.getCreatedAt()
+        );
+    }
+}

--- a/api-server/src/main/java/com/whyitrose/apiserver/memo/dto/MemoUpdateRequest.java
+++ b/api-server/src/main/java/com/whyitrose/apiserver/memo/dto/MemoUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.whyitrose.apiserver.memo.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "메모 수정 요청")
+public record MemoUpdateRequest(
+
+        @Schema(description = "수정할 메모 내용 (최대 300자)", example = "단기 과열은 있었지만 수급이 생각보다 오래 유지됨.")
+        @NotBlank(message = "메모 내용을 입력해주세요.")
+        @Size(max = 300, message = "메모는 최대 300자까지 입력 가능합니다.")
+        String content
+) {
+}

--- a/api-server/src/main/java/com/whyitrose/apiserver/memo/exception/MemoErrorCode.java
+++ b/api-server/src/main/java/com/whyitrose/apiserver/memo/exception/MemoErrorCode.java
@@ -1,0 +1,24 @@
+package com.whyitrose.apiserver.memo.exception;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.whyitrose.core.response.ResponseStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MemoErrorCode implements ResponseStatus {
+
+    MEMO_NOT_FOUND(false, HttpStatus.NOT_FOUND, 4010, "존재하지 않는 메모입니다."),
+    EVENT_NOT_FOUND(false, HttpStatus.NOT_FOUND, 4011, "존재하지 않는 이벤트입니다."),
+    MEMO_FORBIDDEN(false, HttpStatus.FORBIDDEN, 4012, "메모에 대한 권한이 없습니다.");
+
+    private final boolean isSuccess;
+
+    @JsonIgnore
+    private final HttpStatus httpStatus;
+
+    private final int responseCode;
+    private final String responseMessage;
+}

--- a/api-server/src/main/java/com/whyitrose/apiserver/memo/service/MemoService.java
+++ b/api-server/src/main/java/com/whyitrose/apiserver/memo/service/MemoService.java
@@ -1,0 +1,77 @@
+package com.whyitrose.apiserver.memo.service;
+
+import com.whyitrose.apiserver.memo.dto.MemoCreateRequest;
+import com.whyitrose.apiserver.memo.dto.MemoResponse;
+import com.whyitrose.apiserver.memo.dto.MemoUpdateRequest;
+import com.whyitrose.apiserver.memo.exception.MemoErrorCode;
+import com.whyitrose.core.exception.BaseException;
+import com.whyitrose.domain.common.Status;
+import com.whyitrose.domain.event.Event;
+import com.whyitrose.domain.event.EventRepository;
+import com.whyitrose.domain.memo.Memo;
+import com.whyitrose.domain.memo.MemoRepository;
+import com.whyitrose.domain.user.User;
+import com.whyitrose.domain.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemoService {
+
+    private final MemoRepository memoRepository;
+    private final EventRepository eventRepository;
+    private final UserRepository userRepository;
+
+    // ── 메모 목록 조회 ───────────────────────────────────────────────────
+
+    public List<MemoResponse> getMemos(Long userId, Long eventId) {
+        return memoRepository.findByUserIdAndEventIdAndStatusOrderByCreatedAtDesc(userId, eventId, Status.ACTIVE)
+                .stream()
+                .map(MemoResponse::from)
+                .toList();
+    }
+
+    // ── 메모 작성 ────────────────────────────────────────────────────────
+
+    @Transactional
+    public MemoResponse createMemo(Long userId, Long eventId, MemoCreateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BaseException(MemoErrorCode.MEMO_FORBIDDEN));
+
+        Event event = eventRepository.findById(eventId)
+                .filter(e -> e.getStatus() == Status.ACTIVE)
+                .orElseThrow(() -> new BaseException(MemoErrorCode.EVENT_NOT_FOUND));
+
+        Memo memo = Memo.create(user, event, request.content());
+        memoRepository.save(memo);
+
+        return MemoResponse.from(memo);
+    }
+
+    // ── 메모 수정 ────────────────────────────────────────────────────────
+
+    @Transactional
+    public MemoResponse updateMemo(Long userId, Long memoId, MemoUpdateRequest request) {
+        Memo memo = memoRepository.findByIdAndUserIdAndStatus(memoId, userId, Status.ACTIVE)
+                .orElseThrow(() -> new BaseException(MemoErrorCode.MEMO_NOT_FOUND));
+
+        memo.updateContent(request.content());
+
+        return MemoResponse.from(memo);
+    }
+
+    // ── 메모 삭제 ────────────────────────────────────────────────────────
+
+    @Transactional
+    public void deleteMemo(Long userId, Long memoId) {
+        Memo memo = memoRepository.findByIdAndUserIdAndStatus(memoId, userId, Status.ACTIVE)
+                .orElseThrow(() -> new BaseException(MemoErrorCode.MEMO_NOT_FOUND));
+
+        memo.delete();
+    }
+}

--- a/domain/src/main/java/com/whyitrose/domain/event/EventRepository.java
+++ b/domain/src/main/java/com/whyitrose/domain/event/EventRepository.java
@@ -41,4 +41,12 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     Optional<Event> findMergeable(@Param("stockId") Long stockId,
                                   @Param("eventType") EventType eventType,
                                   @Param("prevTradingDate") LocalDate prevTradingDate);
+
+    // 여러 종목의 최신 이벤트 조회 (종목 목록 화면용)
+    @Query("SELECT e FROM Event e " +
+           "WHERE e.stock.id IN :stockIds " +
+           "AND e.status = :status " +
+           "AND e.endDate = (SELECT MAX(e2.endDate) FROM Event e2 WHERE e2.stock.id = e.stock.id AND e2.status = :status)")
+    List<Event> findLatestByStockIds(@Param("stockIds") List<Long> stockIds,
+                                     @Param("status") Status status);
 }

--- a/domain/src/main/java/com/whyitrose/domain/memo/MemoRepository.java
+++ b/domain/src/main/java/com/whyitrose/domain/memo/MemoRepository.java
@@ -4,8 +4,11 @@ import com.whyitrose.domain.common.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MemoRepository extends JpaRepository<Memo, Long> {
 
-    List<Memo> findByUserIdAndEventIdAndStatus(Long userId, Long eventId, Status status);
+    List<Memo> findByUserIdAndEventIdAndStatusOrderByCreatedAtDesc(Long userId, Long eventId, Status status);
+
+    Optional<Memo> findByIdAndUserIdAndStatus(Long id, Long userId, Status status);
 }


### PR DESCRIPTION
## #️⃣ Issue Number
- Closes #68

## 📝 변경사항
이벤트에 대한 메모 CRUD API와 종목 목록의 최신 이벤트 조회 API를 구현했습니다.

### 🎯 핵심 변경 사항 (Key Changes)

- [x] 메모 CRUD API 구현 (조회/작성/수정/삭제)
- [x] 종목 목록의 최신 이벤트 배지 조회 API 추가 (`GET /events/latest`)

### 🔍 주안점 & 리뷰 포인트

- 메모 수정·삭제 시 `findByIdAndUserIdAndStatus`로 본인 소유 여부를 DB 쿼리 단에서 함께 검증합니다.
- 소프트 삭제(`status = DELETED`) 방식을 기존 도메인 패턴과 동일하게 적용했습니다.

---

## 🛠️ PR 유형
- [x] ✨ 새로운 기능 추가

## 🧪 영향 범위 및 테스트 (Impact & Tests)

### **영향을 받는 모듈/컴포넌트:**
`api-server`, `domain`

### **테스트 방법:**
- [x] 수동 API 테스트 (Postman/Swagger)

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 불필요한 로그나 주석을 제거했습니다.
- [x] 관련 이슈를 연결했습니다.
