### PR TITLE
[Feat] interest-stock-API 구현

### DIFF
--- a/api-server/src/main/java/com/whyitrose/apiserver/me/controller/MeInterestStockController.java
+++ b/api-server/src/main/java/com/whyitrose/apiserver/me/controller/MeInterestStockController.java
@@ -1,0 +1,75 @@
+package com.whyitrose.apiserver.me.controller;
+
+import com.whyitrose.apiserver.me.dto.AddInterestStockRequest;
+import com.whyitrose.apiserver.me.service.InterestStockService;
+import com.whyitrose.apiserver.stock.dto.StockDtos.InterestStockListResponse;
+import com.whyitrose.core.exception.BaseException;
+import com.whyitrose.core.response.BaseResponse;
+import com.whyitrose.core.response.BaseResponseStatus;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/me/interest-stocks")
+public class MeInterestStockController {
+
+    private final InterestStockService interestStockService;
+
+    @GetMapping
+    public ResponseEntity<BaseResponse<InterestStockListResponse>> list(Authentication authentication) {
+        Long userId = requireUserId(authentication);
+        return ResponseEntity.ok(BaseResponse.success(interestStockService.list(userId)));
+    }
+
+    @PostMapping
+    public ResponseEntity<BaseResponse<Void>> add(
+            Authentication authentication,
+            @Valid @RequestBody AddInterestStockRequest request
+    ) {
+        Long userId = requireUserId(authentication);
+        interestStockService.add(userId, request.stockId());
+        return ResponseEntity.ok(BaseResponse.success(null));
+    }
+
+    @DeleteMapping("/{stockId}")
+    public ResponseEntity<BaseResponse<Void>> remove(
+            Authentication authentication,
+            @PathVariable Long stockId
+    ) {
+        Long userId = requireUserId(authentication);
+        interestStockService.remove(userId, stockId);
+        return ResponseEntity.ok(BaseResponse.success(null));
+    }
+
+    private Long requireUserId(Authentication authentication) {
+        Long userId = extractPrincipalUserId(authentication);
+        if (userId == null) {
+            throw new BaseException(BaseResponseStatus.UNAUTHORIZED_ACCESS);
+        }
+        return userId;
+    }
+
+    private Long extractPrincipalUserId(Authentication authentication) {
+        if (authentication == null) {
+            return null;
+        }
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof Long id) {
+            return id;
+        }
+        if (principal instanceof Integer id) {
+            return id.longValue();
+        }
+        return null;
+    }
+}

--- a/api-server/src/main/java/com/whyitrose/apiserver/me/dto/AddInterestStockRequest.java
+++ b/api-server/src/main/java/com/whyitrose/apiserver/me/dto/AddInterestStockRequest.java
@@ -1,0 +1,7 @@
+package com.whyitrose.apiserver.me.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record AddInterestStockRequest(
+        @NotNull Long stockId
+) {}

--- a/api-server/src/main/java/com/whyitrose/apiserver/me/service/InterestStockService.java
+++ b/api-server/src/main/java/com/whyitrose/apiserver/me/service/InterestStockService.java
@@ -1,0 +1,67 @@
+package com.whyitrose.apiserver.me.service;
+
+import com.whyitrose.apiserver.stock.dto.StockDtos.InterestStockListResponse;
+import com.whyitrose.apiserver.stock.dto.StockDtos.StockSearchItem;
+import com.whyitrose.apiserver.stock.exception.StockErrorCode;
+import com.whyitrose.apiserver.stock.service.StockService;
+import com.whyitrose.core.exception.BaseException;
+import com.whyitrose.core.response.BaseResponseStatus;
+import com.whyitrose.domain.common.Status;
+import com.whyitrose.domain.interest.InterestStock;
+import com.whyitrose.domain.interest.InterestStockRepository;
+import com.whyitrose.domain.stock.Stock;
+import com.whyitrose.domain.stock.StockRepository;
+import com.whyitrose.domain.user.User;
+import com.whyitrose.domain.user.UserRepository;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class InterestStockService {
+
+    private final InterestStockRepository interestStockRepository;
+    private final UserRepository userRepository;
+    private final StockRepository stockRepository;
+    private final StockService stockService;
+
+    @Transactional(readOnly = true)
+    public InterestStockListResponse list(Long userId) {
+        List<InterestStock> rows = interestStockRepository.findActiveByUserIdWithStock(userId, Status.ACTIVE);
+        List<StockSearchItem> items = rows.stream()
+                .map(InterestStock::getStock)
+                .map(stockService::toSearchItem)
+                .toList();
+        return new InterestStockListResponse(items);
+    }
+
+    @Transactional
+    public void add(Long userId, Long stockId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.UNAUTHORIZED_ACCESS));
+        Stock stock = stockRepository.findById(stockId)
+                .orElseThrow(() -> new BaseException(StockErrorCode.STOCK_001));
+        if (stock.getStatus() != Status.ACTIVE) {
+            throw new BaseException(StockErrorCode.STOCK_001);
+        }
+        Optional<InterestStock> existing = interestStockRepository.findByUserIdAndStockId(userId, stockId);
+        if (existing.isEmpty()) {
+            interestStockRepository.save(InterestStock.create(user, stock));
+            return;
+        }
+        InterestStock row = existing.get();
+        if (row.getStatus() == Status.DELETED) {
+            row.reactivate();
+        }
+    }
+
+    @Transactional
+    public void remove(Long userId, Long stockId) {
+        interestStockRepository.findByUserIdAndStockId(userId, stockId)
+                .filter(is -> is.getStatus() == Status.ACTIVE)
+                .ifPresent(InterestStock::delete);
+    }
+}

--- a/api-server/src/main/java/com/whyitrose/apiserver/stock/dto/StockDtos.java
+++ b/api-server/src/main/java/com/whyitrose/apiserver/stock/dto/StockDtos.java
@@ -40,6 +40,10 @@ public class StockDtos {
             List<StockSearchItem> items
     ) {}
 
+    public record InterestStockListResponse(
+            List<StockSearchItem> items
+    ) {}
+
     public record StockSearchItem(
             Long stockId,
             String ticker,

--- a/api-server/src/main/java/com/whyitrose/apiserver/stock/service/StockService.java
+++ b/api-server/src/main/java/com/whyitrose/apiserver/stock/service/StockService.java
@@ -123,22 +123,24 @@ public class StockService {
 
         List<StockSearchItem> items = dedup.values().stream()
                 .limit(size)
-                .map(stock -> {
-                    PriceSnapshot snapshot = latestSnapshot(stock.getId(), "1D");
-                    return new StockSearchItem(
-                            stock.getId(),
-                            stock.getTicker(),
-                            stock.getName(),
-                            stock.getMarket().name(),
-                            stock.getLogoUrl(),
-                            snapshot.currentPrice,
-                            snapshot.changeRate,
-                            snapshot.direction
-                    );
-                })
+                .map(this::toSearchItem)
                 .toList();
 
         return new StockSearchResponse(q, items.size(), items);
+    }
+
+    public StockSearchItem toSearchItem(Stock stock) {
+        PriceSnapshot snapshot = latestSnapshot(stock.getId(), "1D");
+        return new StockSearchItem(
+                stock.getId(),
+                stock.getTicker(),
+                stock.getName(),
+                stock.getMarket().name(),
+                stock.getLogoUrl(),
+                snapshot.currentPrice,
+                snapshot.changeRate,
+                snapshot.direction
+        );
     }
 
     public StockDetailResponse getStockDetail(Long stockId) {

--- a/domain/src/main/java/com/whyitrose/domain/interest/InterestStockRepository.java
+++ b/domain/src/main/java/com/whyitrose/domain/interest/InterestStockRepository.java
@@ -2,6 +2,8 @@ package com.whyitrose.domain.interest;
 
 import com.whyitrose.domain.common.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -9,6 +11,11 @@ import java.util.Optional;
 public interface InterestStockRepository extends JpaRepository<InterestStock, Long> {
 
     Optional<InterestStock> findByUserIdAndStockId(Long userId, Long stockId);
+
+    @Query("SELECT i FROM InterestStock i JOIN FETCH i.stock "
+            + "WHERE i.user.id = :userId AND i.status = :status ORDER BY i.createdAt DESC")
+    List<InterestStock> findActiveByUserIdWithStock(
+            @Param("userId") Long userId, @Param("status") Status status);
 
     // 현재 활성 관심종목 목록
     List<InterestStock> findByUserIdAndStatus(Long userId, Status status);


### PR DESCRIPTION
## #️⃣ Issue Number
- Closes #74 

## 📝 변경사항
로그인 사용자별 관심종목을 `interest_stocks`에 저장·조회할 수 있도록 `/api/me/interest-stocks` API를 추가했습니다. JWT의 `userId`로만 접근해 유저별 목록이 분리되며, 목록 항목은 검색 API와 동일한 시세 필드를 쓰도록 `StockService.toSearchItem`으로 맞췄습니다.

### 🎯 핵심 변경 사항 (Key Changes)

- [x] `GET/POST/DELETE /api/me/interest-stocks` — 관심종목 목록·추가·해제 (추가 시 기존 행이 `DELETED`면 재활성)
- [x] `InterestStockRepository` — 활성 관심종목 조회 시 `stock` JOIN FETCH 및 `createdAt` 내림차순
- [x] `StockService` — `toSearchItem(Stock)` 공개 메서드 추가, 검색 응답 생성 로직 재사용
- [x] `StockDtos` — `InterestStockListResponse` 추가

### 🔍 주안점 & 리뷰 포인트
- `/api/me/**`는 기존 보안 설정상 인증 필수 경로입니다. 프론트는 Bearer/쿠키와 동일하게 전달해야 합니다.
- 종목 상세 `GET /api/stocks/{id}`의 `isInterested` 자동 반영은 이번 범위에 포함하지 않았습니다. 필요 시 후속 PR에서 `InterestStockRepository` 조회로 연동 가능합니다.

### 🖼️ 스크린샷 / 테스트 결과 (선택 사항)


---

## 🛠️ PR 유형
- [x] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 💄 UI/UX 디자인 변경
- [x] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## 🧪 영향 범위 및 테스트 (Impact & Tests)

### **영향을 받는 모듈/컴포넌트:**
- `domain` — `InterestStockRepository`
- `api-server` — `MeInterestStockController`, `InterestStockService`, `StockService`, `StockDtos`

### **테스트 방법:**
- [ ] 단위 테스트 (JUnit/Jest)
- [ ] 통합 테스트
- [x] 수동 API 테스트 (Postman/Swagger) — 로그인 후 목록/추가/삭제, 타 유저와 목록 분리 확인

## ✅ PR Checklist
- [ ] 커밋 메시지 컨벤션을 준수했습니다.
- [ ] 불필요한 로그나 주석을 제거했습니다.
- [ ] 관련 이슈를 연결했습니다.