### PR TITLE
feat(auth): 푸시 수신 설정 API 분리 및 /auth/me 응답에 pushEnabled 추가

### DIFF
--- a/api-server/src/main/java/com/whyitrose/apiserver/auth/controller/AuthController.java
+++ b/api-server/src/main/java/com/whyitrose/apiserver/auth/controller/AuthController.java
@@ -16,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import com.whyitrose.apiserver.auth.dto.UpdateMeRequest;
+import com.whyitrose.apiserver.auth.dto.UpdatePushEnabledRequest;
 
 @RestController
 @RequiredArgsConstructor
@@ -116,4 +117,15 @@ public class AuthController {
         }
         return null;
     }
+
+    @PatchMapping("/me/push-enabled")
+    public ResponseEntity<BaseResponse<Void>> updatePushEnabled(
+            Authentication authentication,
+            @RequestBody @Valid UpdatePushEnabledRequest request
+    ) {
+        Long userId = extractPrincipalUserId(authentication);
+        authService.updatePushEnabled(userId, request);
+        return ResponseEntity.ok(BaseResponse.success(null));
+    }
+
 }

--- a/api-server/src/main/java/com/whyitrose/apiserver/auth/dto/AuthResult.java
+++ b/api-server/src/main/java/com/whyitrose/apiserver/auth/dto/AuthResult.java
@@ -4,10 +4,11 @@ public record AuthResult(
         Long userId,
         String email,
         String nickname,
+        boolean pushEnabled,
         String accessToken,
         String refreshToken
 ) {
     public LoginResponse toLoginResponse() {
-        return new LoginResponse(userId, email, nickname);
+        return new LoginResponse(userId, email, nickname, pushEnabled);
     }
 }

--- a/api-server/src/main/java/com/whyitrose/apiserver/auth/dto/LoginResponse.java
+++ b/api-server/src/main/java/com/whyitrose/apiserver/auth/dto/LoginResponse.java
@@ -3,5 +3,6 @@ package com.whyitrose.apiserver.auth.dto;
 public record LoginResponse(
         Long userId,
         String email,
-        String nickname
+        String nickname,
+        boolean pushEnabled
 ) {}

--- a/api-server/src/main/java/com/whyitrose/apiserver/auth/dto/UpdatePushEnabledRequest.java
+++ b/api-server/src/main/java/com/whyitrose/apiserver/auth/dto/UpdatePushEnabledRequest.java
@@ -1,0 +1,7 @@
+package com.whyitrose.apiserver.auth.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UpdatePushEnabledRequest(
+        @NotNull Boolean enabled
+) {}

--- a/api-server/src/main/java/com/whyitrose/apiserver/auth/service/AuthService.java
+++ b/api-server/src/main/java/com/whyitrose/apiserver/auth/service/AuthService.java
@@ -24,6 +24,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import com.whyitrose.apiserver.auth.dto.UpdateMeRequest;
+import com.whyitrose.apiserver.auth.dto.UpdatePushEnabledRequest;
 
 import java.time.LocalDateTime;
 
@@ -121,6 +122,7 @@ public class AuthService {
                 user.getId(),
                 user.getEmail(),
                 user.getNickname(),
+                user.isPushEnabled(),
                 newAccessToken,
                 saved.getRefreshToken()
         );
@@ -160,7 +162,7 @@ public class AuthService {
             throw new BaseException(AuthErrorCode.AUTH_013);
         }
 
-        return new LoginResponse(user.getId(), user.getEmail(), user.getNickname());
+        return new LoginResponse(user.getId(), user.getEmail(), user.getNickname(), user.isPushEnabled());
     }
 
     public UserResponse updateMe(Long authenticatedUserId, UpdateMeRequest request) {
@@ -200,6 +202,21 @@ public class AuthService {
         refreshTokenRepository.deleteByUserId(user.getId());
     }
 
+    public void updatePushEnabled(Long authenticatedUserId, UpdatePushEnabledRequest request) {
+        if (authenticatedUserId == null) {
+            throw new BaseException(BaseResponseStatus.UNAUTHORIZED_ACCESS);
+        }
+
+        User user = userRepository.findById(authenticatedUserId)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.INVALID_TOKEN));
+
+        if (user.getStatus() == Status.DELETED) {
+            throw new BaseException(AuthErrorCode.AUTH_013);
+        }
+
+        user.updatePushEnabled(request.enabled());
+    }
+
     private void upsertRefreshToken(User user, String refreshTokenValue) {
         LocalDateTime expiryAt = LocalDateTime.now()
                 .plusSeconds(jwtTokenProvider.getRefreshTokenExpirationMs() / 1000);
@@ -221,6 +238,7 @@ public class AuthService {
                 user.getId(),
                 user.getEmail(),
                 user.getNickname(),
+                user.isPushEnabled(),
                 accessToken,
                 refreshToken
         );


### PR DESCRIPTION
## #️⃣ Issue Number
<!--- ex) #이슈번호, #이슈번호 -->
- Closes #101 
## 📝 변경사항
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 기존 `PATCH /auth/me`(닉네임 수정 전용)에 푸시 설정을 섞지 않고, 푸시 수신 설정을 별도 API로 분리
- `/auth/me` 응답에 `pushEnabled`를 포함해 클라이언트가 서버 기준 푸시 설정 상태를 직접 조회
이렇게 분리함으로써 닉네임 수정 API 회귀 위험을 줄이고, 배치의 기존 발송 조건(push_enabled=true)과 즉시 정합되도록 했습니다.
### 🎯 핵심 변경 사항 (Key Changes)

- [x] `GET /auth/me` 응답(LoginResponse)에 pushEnabled 필드 추가
- [x] 로그인/토큰 재발급 응답에도 `pushEnabled` 포함되도록 `AuthResult` 및 매핑 로직 수정 
- [x] `PATCH /auth/me/push-enabled` 엔드포인트 및 서비스 로직(`user.updatePushEnabled`) 추가

### 🔍 주안점 & 리뷰 포인트
<!--
  (Optional)
  리뷰 시에 유심히 봐주었으면 하는 부분 설명
-->
<!-- 
  - 예: 멀티 모듈 구조에서 의존성 주입 방식이 적절한지 봐주세요.
  - 예: Next.js App Router의 `params` 언래핑(unwrap) 처리가 올바른지 확인 부탁드립니다.
-->

### 🖼️ 스크린샷 / 테스트 결과 (선택 사항)
<!--
  (Optional)
  작업 결과 만들거나 변경된 화면 스크린샷
  테스트 수행 결과 스크린샷
-->
---
- 컴파일 확인: `./gradlew :api-server:compileJava -x test` 성공

## 🛠️ PR 유형
- [x] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 💄 UI/UX 디자인 변경
- [ ] ♻️ 리팩토링
- [ ] 📝 문서 수정 (Docs)
- [ ] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/패키지 매니저/CI 설정 수정

## 🧪 영향 범위 및 테스트 (Impact & Tests)
<!--
  (Optional)
  작업에 의해 영향을 받은 모듈/컴포넌트 설명
  수행한 테스트 설명
-->
### **영향을 받는 모듈/컴포넌트:** 
<!--
  (예: `core-api`, `domain-blog`)
-->
- `api-server/.../auth/controller/AuthController.java`
- `api-server/.../auth/service/AuthService.java`
- `api-server/.../auth/dto/LoginResponse.java`
- `api-server/.../auth/dto/AuthResult.java`
- `api-server/.../auth/dto/UpdatePushEnabledRequest.java` (신규)
### **테스트 방법:**
- [ ] 단위 테스트 (JUnit/Jest)
- [ ] 통합 테스트
- [x] 수동 API 테스트 (Postman/Swagger)

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 불필요한 로그나 주석을 제거했습니다.
- [x] 관련 이슈를 연결했습니다.
